### PR TITLE
Terraforming Land Complete

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -21,3 +21,6 @@ rotation_integer = 0
 
 # BUILDING THE GAMEBOARD
 gameboard = build_iso_gameboard()
+
+# Empty variable to store the value of the cell we are interacting with
+interaction_cell = None

--- a/src/functions/camera_operations.py
+++ b/src/functions/camera_operations.py
@@ -57,6 +57,6 @@ def rotate_camera(key):
     
     # Now, in order for rendering to work, we need to sort the gameboard array
     # As we need the farthest cells to render first
-    config.gameboard = sorted(config.gameboard, key = lambda t: (t['v1'][1], t['v1'][0]))
+    config.gameboard = sorted(config.gameboard, key = lambda t: (t['v1'][1],t['v1'][0]), reverse = True)
     print('Rotation complete')
     print(f'Now rendering sprites of rotation integer {config.rotation_integer}')

--- a/src/functions/input.py
+++ b/src/functions/input.py
@@ -3,7 +3,7 @@ from OpenGL.GLUT import *
 from OpenGL.GLU import *
 
 from .camera_operations import move_camera, rotate_camera
-from .mouse_operations import mouse_hover_mechanics, mouse_click_mechanics
+from .mouse_operations import mouse_hover_mechanics, mouse_click_mechanics, mouse_drag_mechanics
 
 # 'Special' keys here - such as arrow keys, anything non-alphanumeric basically
 def special_keys(key, x, y):
@@ -30,5 +30,11 @@ def mouse_motion(x, y):
 def mouse_click(button, state, x, y):
 
   mouse_click_mechanics(button, state, x, y)
+
+  glutPostRedisplay()
+
+def mouse_dragging(x, y):
+
+  mouse_drag_mechanics(x, y)
 
   glutPostRedisplay()

--- a/src/functions/input.py
+++ b/src/functions/input.py
@@ -3,9 +3,7 @@ from OpenGL.GLUT import *
 from OpenGL.GLU import *
 
 from .camera_operations import move_camera, rotate_camera
-
-# LOADING IN ALL OUR SETUP VARIABLES
-import config
+from .mouse_operations import mouse_hover_mechanics
 
 # 'Special' keys here - such as arrow keys, anything non-alphanumeric basically
 def special_keys(key, x, y):
@@ -19,4 +17,11 @@ def normal_keys(key, x, y):
 
   rotate_camera(key)
   
+  glutPostRedisplay()
+
+# Mouse motion will probs all go in here
+def mouse_motion(x, y):
+
+  mouse_hover_mechanics(x, y)
+
   glutPostRedisplay()

--- a/src/functions/input.py
+++ b/src/functions/input.py
@@ -3,7 +3,7 @@ from OpenGL.GLUT import *
 from OpenGL.GLU import *
 
 from .camera_operations import move_camera, rotate_camera
-from .mouse_operations import mouse_hover_mechanics
+from .mouse_operations import mouse_hover_mechanics, mouse_click_mechanics
 
 # 'Special' keys here - such as arrow keys, anything non-alphanumeric basically
 def special_keys(key, x, y):
@@ -23,5 +23,12 @@ def normal_keys(key, x, y):
 def mouse_motion(x, y):
 
   mouse_hover_mechanics(x, y)
+
+  glutPostRedisplay()
+
+# Mouse Click
+def mouse_click(button, state, x, y):
+
+  mouse_click_mechanics(button, state, x, y)
 
   glutPostRedisplay()

--- a/src/functions/iso_gameboard.py
+++ b/src/functions/iso_gameboard.py
@@ -38,4 +38,4 @@ def build_iso_gameboard():
         'objectHeight': None
       })
 
-  return cells
+  return list(reversed(cells))

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -20,10 +20,10 @@ def mouse_hover_mechanics(x, y):
   for cell in config.gameboard:
 
     # Preparing cell vertices for area intersection detection
-    v1 = add_vectors(cell['v1'], config.camera_offset)
-    v2 = add_vectors(cell['v2'], config.camera_offset)
-    v3 = add_vectors(cell['v3'], config.camera_offset)
-    v4 = add_vectors(cell['v4'], config.camera_offset)
+    v1 = add_vectors(cell['v1'], [0, cell['height']], config.camera_offset)
+    v2 = add_vectors(cell['v2'], [0, cell['height']], config.camera_offset)
+    v3 = add_vectors(cell['v3'], [0, cell['height']], config.camera_offset)
+    v4 = add_vectors(cell['v4'], [0, cell['height']], config.camera_offset)
 
     if is_point_in_quad((gl_x, gl_y), v1, v2, v3, v4):
       
@@ -66,10 +66,5 @@ def mouse_drag_mechanics(x, y):
     # If you ever drag up or down by one unit...
     if units_dragged != 0:
 
-      # Then add that unit to the y-position of the interaction cell..
-      for n in range(4):
-        config.interaction_cell[f'v{n + 1}'][1] += units_dragged
-      # Add the unit to the cells height (so it renders the walls properly)...
       config.interaction_cell['height'] += units_dragged
-      # ... Then reset the starting position!
       click_position = [gl_x, gl_y]

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -1,0 +1,26 @@
+from OpenGL.GL import *
+from OpenGL.GLUT import *
+from OpenGL.GLU import *
+
+from .tools import add_vectors, is_point_in_quad, normalise_pixel_coords
+
+# LOADING IN ALL OUR SETUP VARIABLES
+import config
+
+# Handle the mouse hovering mechanics
+def mouse_hover_mechanics(x, y):
+
+  # Convert pixel coords to normalised (-1, 1) coords
+  gl_x, gl_y = normalise_pixel_coords(x, y)
+
+  for cell in config.gameboard:
+
+    # Preparing cell vertices for area intersection detection
+    v1 = add_vectors(cell['v1'], config.camera_offset)
+    v2 = add_vectors(cell['v2'], config.camera_offset)
+    v3 = add_vectors(cell['v3'], config.camera_offset)
+    v4 = add_vectors(cell['v4'], config.camera_offset)
+
+    if is_point_in_quad((gl_x, gl_y), v1, v2, v3, v4):
+      
+      config.interaction_cell = cell

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -29,9 +29,10 @@ def mouse_hover_mechanics(x, y):
       
       config.interaction_cell = cell
 
+# Handle the mouse clicking mechanics
 def mouse_click_mechanics(button, state, x, y):
 
-  global click_position
+  global click_position, is_dragging
 
   # Convert pixel coords to normalised OpenGL coords
   gl_x, gl_y = normalise_pixel_coords(x, y)
@@ -41,8 +42,29 @@ def mouse_click_mechanics(button, state, x, y):
 
     if state == GLUT_DOWN:
       click_position = [gl_x, gl_y]
+      is_dragging = True
       print(f'Mouse Clicked at: {click_position}')
     
     elif state == GLUT_UP:
       print(f'Mouse unclicked at: [{gl_x}, {gl_y}]')
       click_position = None
+      is_dragging = False
+
+# Handle the mouse being click-dragged on screen
+def mouse_drag_mechanics(x, y):
+
+  global click_position, is_dragging
+
+  gl_x, gl_y = normalise_pixel_coords(x, y)
+
+  if is_dragging:
+    
+    units_dragged = ((gl_y - click_position[1]) // config.unit_height) * config.unit_height
+
+    if units_dragged != 0:
+
+      for n in range(4):
+        config.interaction_cell[f'v{n + 1}'][1] += units_dragged
+
+      config.interaction_cell['height'] += units_dragged
+      click_position = [gl_x, gl_y]

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -7,6 +7,10 @@ from .tools import add_vectors, is_point_in_quad, normalise_pixel_coords
 # LOADING IN ALL OUR SETUP VARIABLES
 import config
 
+# Some dummy variables to handle mouse mechanics
+click_position = None
+is_dragging = False
+
 # Handle the mouse hovering mechanics
 def mouse_hover_mechanics(x, y):
 
@@ -24,3 +28,21 @@ def mouse_hover_mechanics(x, y):
     if is_point_in_quad((gl_x, gl_y), v1, v2, v3, v4):
       
       config.interaction_cell = cell
+
+def mouse_click_mechanics(button, state, x, y):
+
+  global click_position
+
+  # Convert pixel coords to normalised OpenGL coords
+  gl_x, gl_y = normalise_pixel_coords(x, y)
+
+  # Handling left click
+  if button == GLUT_LEFT_BUTTON:
+
+    if state == GLUT_DOWN:
+      click_position = [gl_x, gl_y]
+      print(f'Mouse Clicked at: {click_position}')
+    
+    elif state == GLUT_UP:
+      print(f'Mouse unclicked at: [{gl_x}, {gl_y}]')
+      click_position = None

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -55,16 +55,21 @@ def mouse_drag_mechanics(x, y):
 
   global click_position, is_dragging
 
+  # Normalise mouse coords
   gl_x, gl_y = normalise_pixel_coords(x, y)
 
   if is_dragging:
     
-    units_dragged = ((gl_y - click_position[1]) // config.unit_height) * config.unit_height
+    # Using int(division) instead of floor division, as floor division passes 0 at twice the rate for neg numbers
+    units_dragged = int((gl_y - click_position[1]) / config.unit_height) * config.unit_height
 
+    # If you ever drag up or down by one unit...
     if units_dragged != 0:
 
+      # Then add that unit to the y-position of the interaction cell..
       for n in range(4):
         config.interaction_cell[f'v{n + 1}'][1] += units_dragged
-
+      # Add the unit to the cells height (so it renders the walls properly)...
       config.interaction_cell['height'] += units_dragged
+      # ... Then reset the starting position!
       click_position = [gl_x, gl_y]

--- a/src/functions/render_gameboard.py
+++ b/src/functions/render_gameboard.py
@@ -29,7 +29,9 @@ def render_grid(gameboard):
     glEnd()
 
     # Rendering the grid around the cell
-    glColor(0, 0, 1)
+    glColor(0, 0, 1, 0.5)
+    # Thicker grid if mouse is hovered over it
+    glLineWidth(3) if config.interaction_cell == cell else glLineWidth(0.5)
     glBegin(GL_LINE_LOOP)
     for n in range(4):
       glVertex2f(*add_vectors(cell[f'v{n + 1}'], config.camera_offset))

--- a/src/functions/render_gameboard.py
+++ b/src/functions/render_gameboard.py
@@ -6,26 +6,26 @@ import config
 
 from .tools import add_vectors
 
-def render_grid(gameboard):
+def render_grid():
 
   # Need to reverse the gameboard to render from back-to-front
-  for cell in reversed(gameboard):
+  for cell in config.gameboard:
 
     # Rendering the walls of each cell
     glColor(0.5, 0.5, 0.5)
     glBegin(GL_POLYGON)
-    glVertex2f(cell['v4'][0] + config.camera_offset[0], cell['v4'][1] + config.camera_offset[1])
-    glVertex2f(cell['v4'][0] + config.camera_offset[0], cell['v4'][1] - cell['height'] + config.camera_offset[1])
-    glVertex2f(cell['v1'][0] + config.camera_offset[0], cell['v1'][1] - cell['height'] + config.camera_offset[1])
-    glVertex2f(cell['v2'][0] + config.camera_offset[0], cell['v2'][1] - cell['height'] + config.camera_offset[1])
-    glVertex2f(cell['v2'][0] + config.camera_offset[0], cell['v2'][1] + config.camera_offset[1])
+    glVertex2f(*add_vectors(cell['v4'], [0, cell['height']], config.camera_offset))
+    glVertex2f(*add_vectors(cell['v4'], config.camera_offset))
+    glVertex2f(*add_vectors(cell['v1'], config.camera_offset))
+    glVertex2f(*add_vectors(cell['v2'], config.camera_offset))
+    glVertex2f(*add_vectors(cell['v2'], [0, cell['height']], config.camera_offset))
     glEnd()
     
     # Rendering the actual cell surface
     glColor(*cell['color'])
     glBegin(GL_QUADS)
     for n in range(4):
-      glVertex2f(*add_vectors(cell[f'v{n + 1}'], config.camera_offset))
+      glVertex2f(*add_vectors(cell[f'v{n + 1}'], [0, cell['height']], config.camera_offset))
     glEnd()
 
     # Rendering the grid around the cell
@@ -34,5 +34,5 @@ def render_grid(gameboard):
     glLineWidth(3) if config.interaction_cell == cell else glLineWidth(0.5)
     glBegin(GL_LINE_LOOP)
     for n in range(4):
-      glVertex2f(*add_vectors(cell[f'v{n + 1}'], config.camera_offset))
+      glVertex2f(*add_vectors(cell[f'v{n + 1}'], [0, cell['height']], config.camera_offset))
     glEnd()

--- a/src/functions/tools.py
+++ b/src/functions/tools.py
@@ -29,6 +29,36 @@ def rotate_coordinates(iso_x, iso_y):
 
   return iso_x_rotated, iso_y_rotated
 
+# Convert pixel coordinates to normalised OpenGL coordinates (between -1 and 1 on both axes)
+def normalise_pixel_coords(x, y):
+
+  gl_x = (x / config.window_x) * 2 - 1
+  gl_y = 1 - (y / config.window_y) * 2
+
+  return gl_x, gl_y
+
+# Using Cross Product to determine whether a coordinate lies within a quad
+# First we need a Cross Product function
+def cross_product(p1, p2, p3):
+
+  # Cross Product - A X B = A_x * B_y - A_y * B_x
+  return (p1[0] - p3[0]) * (p2[1] - p3[1]) - (p1[1] - p3[1]) * (p2[0] - p3[0])
+
+# Then we use it as a 'sign test' to determine intersection with area
+def is_point_in_quad(point, v1, v2, v3, v4):
+
+  # If the cross product of the vectors made from these points is less than 0, then the point is 'to the left' of the vertices
+  # So if we provide the vectors in counter-clockwise order, and X-prod is all < 0, then the point must be within the area
+  # Yeah linear algebra we love that shit
+  b1 = cross_product(point, v1, v2) < 0
+  b2 = cross_product(point, v2, v3) < 0
+  b3 = cross_product(point, v3, v4) < 0
+  b4 = cross_product(point, v4, v1) < 0
+
+  # return T/F value
+  return (b1 == b2) and (b2 == b3) and (b3 == b4)
+
+
 # I have no reason to need these - but might be useful
 def add_vectors(v1, v2):
   return [

--- a/src/functions/tools.py
+++ b/src/functions/tools.py
@@ -60,15 +60,15 @@ def is_point_in_quad(point, v1, v2, v3, v4):
 
 
 # I have no reason to need these - but might be useful
-def add_vectors(v1, v2):
+def add_vectors(v1, v2 = [0, 0], v3 = [0, 0]):
   return [
-    v1[0] + v2[0],
-    v1[1] + v2[1]
+    v1[0] + v2[0] + v3[0],
+    v1[1] + v2[1] + v3[1]
   ]
 
-def multiply_vectors(v1, v2):
+def multiply_vectors(v1, v2, v3 = [0, 0]):
 
   return [
-    v1[0] * v2[0],
-    v1[1] * v2[1]
+    v1[0] * v2[0] * v3[0],
+    v1[1] * v2[1] * v3[1]
   ]

--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,7 @@ from OpenGL.GLU import *
 import config
 
 from functions.render_gameboard import render_grid
-from functions.input import special_keys, normal_keys
+from functions.input import special_keys, normal_keys, mouse_motion
 
 # ------------------------------------------ #
 #          | Initialisation Stage |
@@ -51,6 +51,7 @@ def main():
   glutDisplayFunc(draw_scene)
   glutSpecialFunc(special_keys)
   glutKeyboardFunc(normal_keys)
+  glutPassiveMotionFunc(mouse_motion)
 
   # Start the loop of the game
   glutMainLoop()

--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,7 @@ from OpenGL.GLU import *
 import config
 
 from functions.render_gameboard import render_grid
-from functions.input import special_keys, normal_keys, mouse_motion, mouse_click
+from functions.input import special_keys, normal_keys, mouse_motion, mouse_click, mouse_dragging
 
 # ------------------------------------------ #
 #          | Initialisation Stage |
@@ -53,6 +53,7 @@ def main():
   glutKeyboardFunc(normal_keys)
   glutPassiveMotionFunc(mouse_motion)
   glutMouseFunc(mouse_click)
+  glutMotionFunc(mouse_dragging)
 
   # Start the loop of the game
   glutMainLoop()

--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,7 @@ from OpenGL.GLU import *
 import config
 
 from functions.render_gameboard import render_grid
-from functions.input import special_keys, normal_keys, mouse_motion
+from functions.input import special_keys, normal_keys, mouse_motion, mouse_click
 
 # ------------------------------------------ #
 #          | Initialisation Stage |
@@ -52,6 +52,7 @@ def main():
   glutSpecialFunc(special_keys)
   glutKeyboardFunc(normal_keys)
   glutPassiveMotionFunc(mouse_motion)
+  glutMouseFunc(mouse_click)
 
   # Start the loop of the game
   glutMainLoop()

--- a/src/main.py
+++ b/src/main.py
@@ -30,7 +30,7 @@ def draw_scene():
 
   glClear(GL_COLOR_BUFFER_BIT)
 
-  render_grid(config.gameboard)
+  render_grid()
 
   glutSwapBuffers()
 


### PR DESCRIPTION
This has been a TRIP, let me tell you...

SO PRECURSOR, I DECIDED THAT RENDERING ABSOLUTE CELL POSITIONS IS BROKE MATERIAL.
Mainly because when I tried to run a rotation translation on non-uniform-height cells, everything went absolutely to shit. Decided nearly immediately that I need to store the cell vertices at base level, then render their heights off the 'height' scalar.

Luckily this was pretty easy to fix - just patch the render function. Also gave me a chance to expand my add_vectors tool to include an optional third argument - that's kinda fun!

Anyhow, as for the terraforming...

------

**Hover Detection**
Hover detection is achieved using a Cross Product as a 'sign test'. Create two vectors off three points, cross product them together, and use the 'sign' of the output (+'ve / -'ve) to determine which side of the vector the mouse is on. If the X-Prod of four counterclockwise vectors in a quad are all < 0, then the point is within the quad.

The cell hovered over is stored in a global config var called interaction_cell. Might be able to store this in the mouse_operations.py instead of the config, but we can come to that later.

**Mouse click**
Clicking on a cell stores the position of the mouse (in unitised OpenGL coords) in a global var. Also sets a boolean is_dragging var to True.
Unclicking on a cell wipes out the click position and stops the dragging.

**Mouse Drag**
Position of the mouse at any time is stored (again, in unitised OpenGL coords), and compared to the click position using truncated division. As soon as abs(y-delta) hits a multiple of the unit height, add or subtract that unit height onto the interaction_cell['height'] attribute. Then reset the click pos to the current mouse position.

Cool thing about doing it this way, is that the height of the cells updates immediately. Very RCT-esque.

------

There is a fantastic code base here now, and it performs well.
Can't wait to see what this turns into!

