### PR TITLE
Depth Rendering in a single Render function

### DIFF
--- a/src/functions/build_objects.py
+++ b/src/functions/build_objects.py
@@ -3,7 +3,7 @@ from OpenGL.GLUT import *
 from OpenGL.GLU import *
 import random
 
-from .tools import iso_translater, cartesian_translater
+from .tools import iso_translater, cartesian_translater, add_vectors
 
 # LOADING IN ALL OUR SETUP VARIABLES
 import config
@@ -46,14 +46,22 @@ def build_iso_gameboard():
 # Below is suuuuper arbitrary, just space-filling to PoC movement
 def build_object_list():
 
+  # I've just designed a random path here, simply to test depth around terraformed tiles
   points_1 = [
-    [5, 5],
-    [5, 6],
-    [6, 6],
-    [6, 5],
-    [11, 5],
-    [11, 11],
-    [5, 11]
+    [0.5, 0.5],
+    [0.5, 3.5],
+    [8.5, 3.5],
+    [8.5, 1.5],
+    [6.5, 1.5],
+    [6.5, 3.5],
+    [10.5, 3.5],
+    [10.5, 10.5],
+    [9.5, 10.5],
+    [9.5, 8.5],
+    [6.5, 8.5],
+    [6.5, 2.5],
+    [0.5, 2.5],
+
   ]
 
   translated_points_1 = []
@@ -61,37 +69,14 @@ def build_object_list():
   for n in points_1:
     translated_points_1.append(iso_translater(*n))
 
-  points_2 = [
-    [11, 5],
-    [11, 11],
-    [5, 11],
-    [5, 5],
-    [5, 6],
-    [6, 6],
-    [6, 5],
-  ]
-
-  points_2 = list(reversed(points_2))
-  
-  translated_points_2 = []
-
-  for n in points_2:
-    translated_points_2.append(iso_translater(*n))
-
   return [
     {
       'name': 'orb',
       'color': (1, 0, 0),
       'path': translated_points_1,
-      'speed': 0.8,
+      'height': config.unit_height,
+      'speed': 0.2,
       'lastKnownSegment': 0,
       'lastKnownPosition': translated_points_1[0]
-    }, {
-      'name': 'orb',
-      'color': (0, 0, 1),
-      'path': translated_points_2,
-      'speed': 1.2,
-      'lastKnownSegment': 0,
-      'lastKnownPosition': translated_points_2[0]
     }
   ]

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -17,6 +17,8 @@ def mouse_hover_mechanics(x, y):
   # Convert pixel coords to normalised (-1, 1) coords
   gl_x, gl_y = normalise_pixel_coords(x, y)
 
+  config.interaction_cell = None
+
   for cell in config.gameboard:
 
     # Preparing cell vertices for area intersection detection

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -6,46 +6,74 @@ import config
 
 from .tools import add_vectors
 
-def render_grid():
 
-  # Need to reverse the gameboard to render from back-to-front
-  for cell in config.gameboard:
+# Fuck it let's just try rendering everything???
+def render_everything():
 
-    # Rendering the walls of each cell
-    glColor(0.5, 0.5, 0.5)
-    glBegin(GL_POLYGON)
-    glVertex2f(*add_vectors(cell['v4'], [0, cell['height']], config.camera_offset))
-    glVertex2f(*add_vectors(cell['v4'], config.camera_offset))
-    glVertex2f(*add_vectors(cell['v1'], config.camera_offset))
-    glVertex2f(*add_vectors(cell['v2'], config.camera_offset))
-    glVertex2f(*add_vectors(cell['v2'], [0, cell['height']], config.camera_offset))
-    glEnd()
+  all_objects = []
+
+  # Step 1: let's put all the cell coordinates into a list
+  for n in range(len(config.gameboard)):
+
+    all_objects.append({
+      'type': 0,
+      'index': n,
+      'coord': config.gameboard[n]['v3']
+    })
+  
+  # Step 2: let's put all the object positions into a list
+  for n in range(len(config.objects)):
+
+    all_objects.append({
+      'type': 1,
+      'index': n,
+      'coord': config.objects[n]['lastKnownPosition']
+    })
+
+  # Now let's sort EVERYTHING in descending order
+  all_objects = sorted(all_objects, key = lambda t: (t['coord'][1], t['coord'][0], t['type']), reverse = True)
+
+  # Now we CONDITIONALLY render them - if object, do the object thing, if cell do the cell thing
+  for item in all_objects:
+
+    if item['type'] == 0:
+
+      cell = config.gameboard[item['index']]
+
+      # Rendering the walls of each cell
+      glColor(0.5, 0.5, 0.5)
+      glBegin(GL_POLYGON)
+      glVertex2f(*add_vectors(cell['v4'], [0, cell['height']], config.camera_offset))
+      glVertex2f(*add_vectors(cell['v4'], config.camera_offset))
+      glVertex2f(*add_vectors(cell['v1'], config.camera_offset))
+      glVertex2f(*add_vectors(cell['v2'], config.camera_offset))
+      glVertex2f(*add_vectors(cell['v2'], [0, cell['height']], config.camera_offset))
+      glEnd()
+
+      # Rendering the actual cell surface
+      glColor(*cell['color'])
+      glBegin(GL_QUADS)
+      for n in range(4):
+        glVertex2f(*add_vectors(cell[f'v{n + 1}'], [0, cell['height']], config.camera_offset))
+      glEnd()
+
+      # Rendering the grid around the cell
+      glColor(0, 0, 1, 0.5)
+      glLineWidth(3) if config.interaction_cell == cell else glLineWidth(0.5) # Thicker grid if mouse hover
+      glBegin(GL_LINE_LOOP)
+      for n in range(4):
+        glVertex2f(*add_vectors(cell[f'v{n + 1}'], [0, cell['height']], config.camera_offset))
+      glEnd()
     
-    # Rendering the actual cell surface
-    glColor(*cell['color'])
-    glBegin(GL_QUADS)
-    for n in range(4):
-      glVertex2f(*add_vectors(cell[f'v{n + 1}'], [0, cell['height']], config.camera_offset))
-    glEnd()
+    elif item['type'] == 1:
 
-    # Rendering the grid around the cell
-    glColor(0, 0, 1, 0.5)
-    glLineWidth(3) if config.interaction_cell == cell else glLineWidth(0.5) # Thicker grid if mouse hover
-    glBegin(GL_LINE_LOOP)
-    for n in range(4):
-      glVertex2f(*add_vectors(cell[f'v{n + 1}'], [0, cell['height']], config.camera_offset))
-    glEnd()
+      object = config.objects[item['index']]
 
-# Render non-static objects
-def render_objects():
-
-  for object in config.objects:
-
-    # For now I'm just rendering a super basic quad around a point - just to PoC this
-    glColor(*object['color'])
-    glBegin(GL_QUADS)
-    glVertex2f(*add_vectors(object['lastKnownPosition'], [-0.01, -0.01], [0, config.unit_height], config.camera_offset))
-    glVertex2f(*add_vectors(object['lastKnownPosition'], [0.01, -0.01], [0, config.unit_height], config.camera_offset))
-    glVertex2f(*add_vectors(object['lastKnownPosition'], [0.01, 0.01], [0, config.unit_height], config.camera_offset))
-    glVertex2f(*add_vectors(object['lastKnownPosition'], [-0.01, 0.01], [0, config.unit_height], config.camera_offset))
-    glEnd()
+      # For now I'm just rendering a super basic quad around a point - just to PoC this
+      glColor(*object['color'])
+      glBegin(GL_QUADS)
+      glVertex2f(*add_vectors(object['lastKnownPosition'], [-0.01, -0.01], [0, object['height']], config.camera_offset))
+      glVertex2f(*add_vectors(object['lastKnownPosition'], [0.01, -0.01], [0, object['height']], config.camera_offset))
+      glVertex2f(*add_vectors(object['lastKnownPosition'], [0.01, 0.01], [0, object['height']], config.camera_offset))
+      glVertex2f(*add_vectors(object['lastKnownPosition'], [-0.01, 0.01], [0, object['height']], config.camera_offset))
+      glEnd()

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from OpenGL.GLU import *
 # LOADING IN ALL OUR SETUP VARIABLES
 import config
 
-from functions.rendering import render_grid, render_objects
+from functions.rendering import render_everything
 from functions.input import special_keys, normal_keys, mouse_motion, mouse_click, mouse_dragging
 from functions.object_movement import update_object_positions
 
@@ -33,8 +33,9 @@ def draw_scene():
 
   glClear(GL_COLOR_BUFFER_BIT)
 
-  render_grid()
-  render_objects()
+  render_everything()
+  # render_grid()
+  # render_objects()
 
   glutSwapBuffers()
   # Below function FORCES a rerender - which you need to render the objects movement


### PR DESCRIPTION
So I'm not sure if I'm going to go down this route long-term, but it's good enough to start developing other features.

Basically, what I'm doing is, for each render loop:
1. Take an identical array of 'coordinate', 'type', 'index' for each of Cells and Objects
2. Union the two arrays together
3. Sort them in descending order
4. Use the 'type' to decide which render function to use (object or cell), and the corresponding 'index' to retrieve the item from the respective array.

This means that objects are sorted to render after the cell they belong to, without needing to place the object anywhere in the cell array. Makes for much easier object behaviour definitions, while maintaining complete layer order.

Worth noting that the 'object' array now has a 'height' attribute, as I figured out that I need the object position to be defined in the same base plane as the 'cells' - as what happens if the object coords are actually up really high? This will undoubtedly make 3-space rendering of objects a bunch harder, as well as updating the location of the object - but I'm *fairly* sure I can solve that with some basic O(1) trigonometry.

Tbh there might be more stuff I've forgotten to cover - look at the commit history - but I just wanna get started on the next section now.