### PR TITLE
v1 of HUD

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -19,11 +19,24 @@ camera_offset = [0, -1 * gameboard_dimensions[0] * unit_height]
 # Rotation integer ranges from 0-3 and tells the game which sprites to render
 rotation_integer = 0
 
+# ------------ CELLS ------------ #
+
 # BUILDING THE GAMEBOARD, and the order to render the gameboard in
 gameboard, cell_render_order = build_iso_gameboard()
 
 # Empty variable to store the value of the cell we are interacting with
 interaction_cell = None
+
+# ------------- HUD ------------- #
+
+# Top bar boxes
+hud_icon_x = 0.07
+hud_icon_y = hud_icon_x * window_x / window_y
+
+# Dictate which 'mode' the user is in
+user_data = {
+  'mode': None
+}
 
 
 # ------- TESTING OBJECT MOVEMENT ------- #

--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,4 @@
-from functions.build_objects import build_iso_gameboard, build_object_list
+from functions.build_objects import build_iso_gameboard, build_object_list, build_hud
 
 # BRAND NEW PATTER JUST DROPPED
 # STORE ALL YOUR CONSTANTS IN THIS CONFIG FILE
@@ -32,6 +32,9 @@ interaction_cell = None
 # Top bar boxes
 hud_icon_x = 0.07
 hud_icon_y = hud_icon_x * window_x / window_y
+
+# Actual HUD button array
+hud_buttons = build_hud(['terraform', 'construct_path'])
 
 # Dictate which 'mode' the user is in
 user_data = {

--- a/src/config.py
+++ b/src/config.py
@@ -38,7 +38,7 @@ hud_buttons = build_hud(['terraform', 'construct_path'])
 
 # Dictate which 'mode' the user is in
 user_data = {
-  'mode': None
+  'mode': 'terraform'
 }
 
 

--- a/src/functions/build_objects.py
+++ b/src/functions/build_objects.py
@@ -81,3 +81,22 @@ def build_object_list():
       'lastKnownPosition': translated_points_1[0]
     }
   ]
+
+
+def build_hud(button_names):
+
+  button_dict = {}
+
+  for n in range(len(button_names)):
+
+    x_pos = config.hud_icon_x * n
+
+    button_dict[button_names[n]] = {
+      'buttonName': button_names[n],
+      'v1': (-1 + x_pos, 1 - config.hud_icon_y),
+      'v2': (-1 + x_pos + config.hud_icon_x, 1 - config.hud_icon_y),
+      'v3': (-1 + x_pos + config.hud_icon_x, 1),
+      'v4': (-1 + x_pos, 1)
+    }
+  
+  return button_dict

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -46,6 +46,18 @@ def mouse_click_mechanics(button, state, x, y):
 
     if state == GLUT_DOWN:
       click_position = [gl_x, gl_y]
+
+      # First - are we clicking on a HUD button?
+      for button_index in list(config.hud_buttons.keys()):
+        button = config.hud_buttons[button_index]
+
+        if is_point_in_quad((gl_x, gl_y), button['v1'], button['v2'], button['v3'], button['v4']):
+
+          print(f'Clicked on the {button['buttonName']} button')
+          config.user_data['mode'] = button['buttonName']
+      
+      # Then we handle all the other stuff (at this stage just for terraforming)
+
       is_dragging = True
       print(f'Mouse Clicked at: {click_position}')
     
@@ -62,7 +74,8 @@ def mouse_drag_mechanics(x, y):
   # Normalise mouse coords
   gl_x, gl_y = normalise_pixel_coords(x, y)
 
-  if is_dragging:
+  # Only activate a 'dragging' motion if the mouse has clicked down, and if the user mode is 'terraform'
+  if is_dragging and config.user_data['mode'] == 'terraform':
     
     # Using int(division) instead of floor division, as floor division passes 0 at twice the rate for neg numbers
     units_dragged = int((gl_y - click_position[1]) / config.unit_height) * config.unit_height

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -85,3 +85,14 @@ def render_with_dictionary():
       glVertex2f(*add_vectors(object['lastKnownPosition'], [0.01, 0.01], [0, object['height']], config.camera_offset))
       glVertex2f(*add_vectors(object['lastKnownPosition'], [-0.01, 0.01], [0, object['height']], config.camera_offset))
       glEnd()
+
+
+def render_hud():
+
+  glColor(1, 1, 1)
+  glBegin(GL_QUADS)
+  glVertex2f(0 - config.hud_icon_x, 1)
+  glVertex2f(0, 1)
+  glVertex2f(0, 1 - config.hud_icon_y)
+  glVertex2f(0 - config.hud_icon_x, 1 - config.hud_icon_y)
+  glEnd()

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -94,7 +94,7 @@ def render_hud():
     button = config.hud_buttons[button_index]
 
     # Render button background
-    glColor(1, 1, 1)
+    glColor(1, 0.7, 0.7) if config.user_data['mode'] == button['buttonName'] else glColor(1, 1, 1)
     glBegin(GL_QUADS)
     for n in range(4):
       glVertex2f(*button[f'v{n + 1}'])

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -89,10 +89,20 @@ def render_with_dictionary():
 
 def render_hud():
 
-  glColor(1, 1, 1)
-  glBegin(GL_QUADS)
-  glVertex2f(0 - config.hud_icon_x, 1)
-  glVertex2f(0, 1)
-  glVertex2f(0, 1 - config.hud_icon_y)
-  glVertex2f(0 - config.hud_icon_x, 1 - config.hud_icon_y)
-  glEnd()
+  for button_index in list(config.hud_buttons.keys()):
+
+    button = config.hud_buttons[button_index]
+
+    # Render button background
+    glColor(1, 1, 1)
+    glBegin(GL_QUADS)
+    for n in range(4):
+      glVertex2f(*button[f'v{n + 1}'])
+    glEnd()
+
+    # Render button outline
+    glColor(0.4, 0.4, 0.4)
+    glBegin(GL_LINE_LOOP)
+    for n in range(4):
+      glVertex2f(*button[f'v{n + 1}'])
+    glEnd()

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from OpenGL.GLU import *
 # LOADING IN ALL OUR SETUP VARIABLES
 import config
 
-from functions.rendering import render_with_dictionary
+from functions.rendering import render_with_dictionary, render_hud
 from functions.input import special_keys, normal_keys, mouse_motion, mouse_click, mouse_dragging
 from functions.object_movement import update_object_positions
 
@@ -33,8 +33,8 @@ def draw_scene():
 
   glClear(GL_COLOR_BUFFER_BIT)
 
-  # render_everything()
   render_with_dictionary()
+  render_hud()
 
   glutSwapBuffers()
   # Below function FORCES a rerender - which you need to render the objects movement


### PR DESCRIPTION
Basically the pre-stage for Construction build engine - need togglable buttons to click on.

Buttons have a standardised width and length which scales according to the 1024x768 resolution. That's pretty cool.

Decided to store the buttons in a dictionary, which allows me to define the quad coordinates explicitly. This makes intersection suuuper easy using the Cross Product sign-test stuff I built for terraforming.

On click:
1. for each button in dictionary, run sign test.
2. if comes back positive then update the user_data['mode'] to the name of the button being clicked on

Simple as that.

Have also set up the buttons to shade in red if they match the Mode value.

HAVE ALSO BLOCKED TERRAFORMING UNLESS IT HAS BEEN EXPLICITLY SELECTED. SUPER COOL.