### PR TITLE
Game Mode Popup mechanics + rendering

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,9 @@
-from functions.build_objects import build_iso_gameboard, build_object_list, build_hud
+from functions.build_objects import (
+  build_iso_gameboard,
+  build_object_list,
+  build_hud,
+  build_popup_windows
+)
 
 # BRAND NEW PATTER JUST DROPPED
 # STORE ALL YOUR CONSTANTS IN THIS CONFIG FILE
@@ -34,13 +39,27 @@ hud_icon_x = 0.07
 hud_icon_y = hud_icon_x * window_x / window_y
 
 # Actual HUD button array
-hud_buttons = build_hud(['terraform', 'construct_path'])
+hud_buttons = build_hud(['terraform', 'constructPath'])
 
 # Dictate which 'mode' the user is in
 user_data = {
   'mode': 'terraform'
 }
 
+# Popup windows stored in a dict as well (for now)
+
+popup_definition = [
+  {
+    'name': 'constructPath',
+    'buttons': [
+      'left',
+      'forward',
+      'right'
+    ]
+  }
+]
+
+popup_windows = build_popup_windows(popup_definition)
 
 # ------- TESTING OBJECT MOVEMENT ------- #
 objects = build_object_list()

--- a/src/config.py
+++ b/src/config.py
@@ -43,7 +43,7 @@ hud_buttons = build_hud(['terraform', 'constructPath'])
 
 # Dictate which 'mode' the user is in
 user_data = {
-  'mode': 'terraform'
+  'mode': None
 }
 
 # Popup windows stored in a dict as well (for now)
@@ -55,6 +55,12 @@ popup_definition = [
       'left',
       'forward',
       'right'
+    ]
+  }, {
+    'name': 'terraform',
+    'buttons': [
+      'increase',
+      'decrease',
     ]
   }
 ]

--- a/src/functions/build_objects.py
+++ b/src/functions/build_objects.py
@@ -135,12 +135,12 @@ def build_popup_windows(popup_definition):
       # Then indent the x-position, ready for the next one!
       button_starting_x += config.hud_icon_x
 
-  # The main window the buttons are to sit in - basically just button perimeters with a 0.01 buffer around edges
-  popup_dict[popup_name]['v1'] = (-1 * n_buttons * config.hud_icon_x / 2 - 0.01, 0.79 - config.hud_icon_y)
-  popup_dict[popup_name]['v2'] = (n_buttons * config.hud_icon_x / 2 + 0.01, 0.79 - config.hud_icon_y)
-  popup_dict[popup_name]['v3'] = (n_buttons * config.hud_icon_x / 2 + 0.01, 0.81)
-  popup_dict[popup_name]['v4'] = (-1 * n_buttons * config.hud_icon_x / 2 - 0.01, 0.81)
+    # The main window the buttons are to sit in - basically just button perimeters with a 0.01 buffer around edges
+    popup_dict[popup_name]['v1'] = (-1 * n_buttons * config.hud_icon_x / 2 - 0.01, 0.79 - config.hud_icon_y)
+    popup_dict[popup_name]['v2'] = (n_buttons * config.hud_icon_x / 2 + 0.01, 0.79 - config.hud_icon_y)
+    popup_dict[popup_name]['v3'] = (n_buttons * config.hud_icon_x / 2 + 0.01, 0.81)
+    popup_dict[popup_name]['v4'] = (-1 * n_buttons * config.hud_icon_x / 2 - 0.01, 0.81)
 
-  popup_dict[popup_name]['color'] = (0.8, 0.8, 0.8)
+    popup_dict[popup_name]['color'] = (0.8, 0.8, 0.8)
 
   return popup_dict

--- a/src/functions/build_objects.py
+++ b/src/functions/build_objects.py
@@ -82,6 +82,7 @@ def build_object_list():
     }
   ]
 
+# Building a dictionary for the HUD buttons, based on a list of button names
 
 def build_hud(button_names):
 
@@ -100,3 +101,46 @@ def build_hud(button_names):
     }
   
   return button_dict
+
+# Building a dictionary of popup windows, based on a list of popup definitions
+
+def build_popup_windows(popup_definition):
+
+  popup_dict = {}
+
+  for popup in popup_definition:
+
+    popup_name = popup['name']
+
+    popup_dict[popup_name] = {
+      'buttons': []
+    }
+
+    # Need to figure out how many buttons the popup is to have - so as to centre them in the screen
+    n_buttons = len(popup['buttons'])
+    button_starting_x = -1 * n_buttons * config.hud_icon_x / 2
+
+    # For each of the buttons the popup is to have...
+    for button in popup['buttons']:
+
+      # Put them in the dictionary
+      popup_dict[popup_name]['buttons'].append({
+        'name': button,
+        'v1': (button_starting_x, 0.8 - config.hud_icon_y),
+        'v2': (button_starting_x + config.hud_icon_x, 0.8 - config.hud_icon_y),
+        'v3': (button_starting_x + config.hud_icon_x, 0.8),
+        'v4': (button_starting_x, 0.8)
+      })
+
+      # Then indent the x-position, ready for the next one!
+      button_starting_x += config.hud_icon_x
+
+  # The main window the buttons are to sit in - basically just button perimeters with a 0.01 buffer around edges
+  popup_dict[popup_name]['v1'] = (-1 * n_buttons * config.hud_icon_x / 2 - 0.01, 0.79 - config.hud_icon_y)
+  popup_dict[popup_name]['v2'] = (n_buttons * config.hud_icon_x / 2 + 0.01, 0.79 - config.hud_icon_y)
+  popup_dict[popup_name]['v3'] = (n_buttons * config.hud_icon_x / 2 + 0.01, 0.81)
+  popup_dict[popup_name]['v4'] = (-1 * n_buttons * config.hud_icon_x / 2 - 0.01, 0.81)
+
+  popup_dict[popup_name]['color'] = (0.8, 0.8, 0.8)
+
+  return popup_dict

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -54,7 +54,12 @@ def mouse_click_mechanics(button, state, x, y):
         if is_point_in_quad((gl_x, gl_y), button['v1'], button['v2'], button['v3'], button['v4']):
 
           print(f'Clicked on the {button['buttonName']} button')
-          config.user_data['mode'] = button['buttonName']
+
+          # Below allows for toggling on buttons - if you're already in Terraform then exit Terraform
+          if config.user_data['mode'] == button['buttonName']:
+            config.user_data['mode'] = None
+          else:
+            config.user_data['mode'] = button['buttonName']
       
       # Then we handle all the other stuff (at this stage just for terraforming)
 

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -106,3 +106,41 @@ def render_hud():
     for n in range(4):
       glVertex2f(*button[f'v{n + 1}'])
     glEnd()
+
+
+
+def render_popup_windows():
+
+  # So far am just building a popup for the 'constructPath' mode - but this can be generalised
+  if config.user_data['mode'] == 'constructPath':
+
+    window_to_render = config.popup_windows[config.user_data['mode']]
+
+    # Render the panel for the buttons to sit on
+    glColor(window_to_render['color'])
+    glBegin(GL_QUADS)
+    for n in range(4):
+      glVertex2f(*window_to_render[f'v{n + 1}'])
+    glEnd()
+
+    # Render each button + outline on top of the panel
+    # Oh GOD this is painful lol
+    for button in config.popup_windows[config.user_data['mode']]['buttons']:
+
+      glColor(1, 1, 1)
+      glBegin(GL_QUADS)
+      for n in range(4):
+        glVertex2f(*button['v1'])
+        glVertex2f(*button['v2'])
+        glVertex2f(*button['v3'])
+        glVertex2f(*button['v4'])
+      glEnd()
+
+      glColor(0.4, 0.4, 0.4)
+      glBegin(GL_LINE_LOOP)
+      for n in range(4):
+        glVertex2f(*button['v1'])
+        glVertex2f(*button['v2'])
+        glVertex2f(*button['v3'])
+        glVertex2f(*button['v4'])
+      glEnd()

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -110,9 +110,8 @@ def render_hud():
 
 
 def render_popup_windows():
-
-  # So far am just building a popup for the 'constructPath' mode - but this can be generalised
-  if config.user_data['mode'] == 'constructPath':
+  
+  if config.user_data['mode'] != None:
 
     window_to_render = config.popup_windows[config.user_data['mode']]
 
@@ -124,23 +123,16 @@ def render_popup_windows():
     glEnd()
 
     # Render each button + outline on top of the panel
-    # Oh GOD this is painful lol
     for button in config.popup_windows[config.user_data['mode']]['buttons']:
 
       glColor(1, 1, 1)
       glBegin(GL_QUADS)
       for n in range(4):
-        glVertex2f(*button['v1'])
-        glVertex2f(*button['v2'])
-        glVertex2f(*button['v3'])
-        glVertex2f(*button['v4'])
+        glVertex2f(*button[f'v{n + 1}'])
       glEnd()
 
       glColor(0.4, 0.4, 0.4)
       glBegin(GL_LINE_LOOP)
       for n in range(4):
-        glVertex2f(*button['v1'])
-        glVertex2f(*button['v2'])
-        glVertex2f(*button['v3'])
-        glVertex2f(*button['v4'])
+        glVertex2f(*button[f'v{n + 1}'])
       glEnd()

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from OpenGL.GLU import *
 # LOADING IN ALL OUR SETUP VARIABLES
 import config
 
-from functions.rendering import render_with_dictionary, render_hud
+from functions.rendering import render_with_dictionary, render_hud, render_popup_windows
 from functions.input import special_keys, normal_keys, mouse_motion, mouse_click, mouse_dragging
 from functions.object_movement import update_object_positions
 
@@ -34,6 +34,7 @@ def draw_scene():
   glClear(GL_COLOR_BUFFER_BIT)
 
   render_with_dictionary()
+  render_popup_windows()
   render_hud()
 
   glutSwapBuffers()


### PR DESCRIPTION
Popup windows are the first step to a cohesive building process - as the user needs something to interact with.

This is achieved using the following -
1. **Popup Definition** - list of dictionaries defining each of the user 'modes', how many buttons should be present to interact with, and the names for the buttons.
2. **Generalised Popup Builder** - takes the list of dictionaries and builds a single dictionary with all popup definitions within it. This includes a back panel, plus all buttons atop the panel, all in the standard 'v1-v4' vertex pattern I have been using.
3. **Rendering** - if the game_data['mode'] is not NoneType (no mode selected) then fetch the definition of the respective mode popup and render it.

In doing this, though, I had to introduce the 'NoneType' mode - otherwise there would always be a popup being rendered. Thus, a 'toggle' functionality has been added to the 'click on HUD buttons' action - whereby if the button being clicked on is the same as the current mode, then replace the mode with None.

Popup windows are rendered after the iso board, though before the HUD. They are not affected by camera offset, nor translated in rotation - completely static.

Very good starting point to begin work on a construction engine.