### PR TITLE
Rebase cell vertices to 0 and keep them static in rotation

### DIFF
--- a/src/functions/build_objects.py
+++ b/src/functions/build_objects.py
@@ -28,10 +28,10 @@ def build_iso_gameboard():
       v4_x, v4_y = iso_translater(x, y + 1)
 
       cells[(x, y)] = {
-        'v1': [v1_x, v1_y],
-        'v2': [v2_x, v2_y],
-        'v3': [v3_x, v3_y],
-        'v4': [v4_x, v4_y],
+        'v0': [v1_x, v1_y],
+        'v1': [v2_x, v2_y],
+        'v2': [v3_x, v3_y],
+        'v3': [v4_x, v4_y],
         'height': config.unit_height,
         'color': (1, 1, 1 / (y + 0.0001)),
         'objectOnCell': None,
@@ -94,10 +94,10 @@ def build_hud(button_names):
 
     button_dict[button_names[n]] = {
       'buttonName': button_names[n],
-      'v1': (-1 + x_pos, 1 - config.hud_icon_y),
-      'v2': (-1 + x_pos + config.hud_icon_x, 1 - config.hud_icon_y),
-      'v3': (-1 + x_pos + config.hud_icon_x, 1),
-      'v4': (-1 + x_pos, 1)
+      'v0': (-1 + x_pos, 1 - config.hud_icon_y),
+      'v1': (-1 + x_pos + config.hud_icon_x, 1 - config.hud_icon_y),
+      'v2': (-1 + x_pos + config.hud_icon_x, 1),
+      'v3': (-1 + x_pos, 1)
     }
   
   return button_dict
@@ -126,20 +126,20 @@ def build_popup_windows(popup_definition):
       # Put them in the dictionary
       popup_dict[popup_name]['buttons'].append({
         'name': button,
-        'v1': (button_starting_x, 0.8 - config.hud_icon_y),
-        'v2': (button_starting_x + config.hud_icon_x, 0.8 - config.hud_icon_y),
-        'v3': (button_starting_x + config.hud_icon_x, 0.8),
-        'v4': (button_starting_x, 0.8)
+        'v0': (button_starting_x, 0.8 - config.hud_icon_y),
+        'v1': (button_starting_x + config.hud_icon_x, 0.8 - config.hud_icon_y),
+        'v2': (button_starting_x + config.hud_icon_x, 0.8),
+        'v3': (button_starting_x, 0.8)
       })
 
       # Then indent the x-position, ready for the next one!
       button_starting_x += config.hud_icon_x
 
     # The main window the buttons are to sit in - basically just button perimeters with a 0.01 buffer around edges
-    popup_dict[popup_name]['v1'] = (-1 * n_buttons * config.hud_icon_x / 2 - 0.01, 0.79 - config.hud_icon_y)
-    popup_dict[popup_name]['v2'] = (n_buttons * config.hud_icon_x / 2 + 0.01, 0.79 - config.hud_icon_y)
-    popup_dict[popup_name]['v3'] = (n_buttons * config.hud_icon_x / 2 + 0.01, 0.81)
-    popup_dict[popup_name]['v4'] = (-1 * n_buttons * config.hud_icon_x / 2 - 0.01, 0.81)
+    popup_dict[popup_name]['v0'] = (-1 * n_buttons * config.hud_icon_x / 2 - 0.01, 0.79 - config.hud_icon_y)
+    popup_dict[popup_name]['v1'] = (n_buttons * config.hud_icon_x / 2 + 0.01, 0.79 - config.hud_icon_y)
+    popup_dict[popup_name]['v2'] = (n_buttons * config.hud_icon_x / 2 + 0.01, 0.81)
+    popup_dict[popup_name]['v3'] = (-1 * n_buttons * config.hud_icon_x / 2 - 0.01, 0.81)
 
     popup_dict[popup_name]['color'] = (0.8, 0.8, 0.8)
 

--- a/src/functions/camera_operations.py
+++ b/src/functions/camera_operations.py
@@ -1,7 +1,6 @@
 from OpenGL.GL import *
 from OpenGL.GLUT import *
 from OpenGL.GLU import *
-from copy import deepcopy
 
 from .tools import rotate_coordinates
 
@@ -35,22 +34,13 @@ def rotate_camera(key):
 
       # Retrieve the cell from the dictionary using the cell index
       cell = config.gameboard[cell_index]
-      
-      # Storing v1 as will be overwriting it in loop
-      # Need to deepcopy as taking item from dictionary
-      v1 = deepcopy(cell['v1'])
-      for n in [4, 3, 2, 1]:
 
-        iso_x, iso_y = rotate_coordinates(*v1) if n == 1 else rotate_coordinates(*cell[f'v{n}'])
+      for n in range(4):
 
-        # NOW WE WRITE BACK TO THE CELL
-        # Using this 'if' condition as 4 % 4 = 0. We need it to be 4
-        if n == 3:
-          cell['v4'][0] = iso_x
-          cell['v4'][1] = iso_y
-        else:
-          cell[f'v{(n + 1) % 4}'][0] = iso_x
-          cell[f'v{(n + 1) % 4}'][1] = iso_y
+        iso_x, iso_y = rotate_coordinates(*cell[f'v{n}'])
+
+        cell[f'v{n}'][0] = iso_x
+        cell[f'v{n}'][1] = iso_y
     
     # Also need to rotate all the object paths and current positions
     for object in config.objects:
@@ -72,6 +62,6 @@ def rotate_camera(key):
     config.rotation_integer = (config.rotation_integer + 1) % 4
     
     # Now, in order for rendering to work, we need to sort the 'render order' array, in descending Y, then descending X within
-    config.cell_render_order = sorted(config.gameboard.keys(), key = lambda t: (config.gameboard[t]['v1'][1], config.gameboard[t]['v1'][0]), reverse = True)
+    config.cell_render_order = sorted(config.gameboard.keys(), key = lambda t: (config.gameboard[t]['v0'][1], config.gameboard[t]['v0'][0]), reverse = True)
     print('Rotation complete')
     print(f'Now rendering sprites of rotation integer {config.rotation_integer}')

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -25,12 +25,12 @@ def mouse_hover_mechanics(x, y):
     cell = config.gameboard[cell_index]
 
     # Preparing cell vertices for area intersection detection
+    v0 = add_vectors(cell['v0'], [0, cell['height']], config.camera_offset)
     v1 = add_vectors(cell['v1'], [0, cell['height']], config.camera_offset)
     v2 = add_vectors(cell['v2'], [0, cell['height']], config.camera_offset)
     v3 = add_vectors(cell['v3'], [0, cell['height']], config.camera_offset)
-    v4 = add_vectors(cell['v4'], [0, cell['height']], config.camera_offset)
 
-    if is_point_in_quad((gl_x, gl_y), v1, v2, v3, v4):
+    if is_point_in_quad((gl_x, gl_y), v0, v1, v2, v3):
       
       # config.interaction_cell = cell
       config.interaction_cell = cell_index
@@ -54,7 +54,7 @@ def mouse_click_mechanics(button, state, x, y):
       for button_index in list(config.hud_buttons.keys()):
         button = config.hud_buttons[button_index]
 
-        if is_point_in_quad((gl_x, gl_y), button['v1'], button['v2'], button['v3'], button['v4']):
+        if is_point_in_quad((gl_x, gl_y), button['v0'], button['v1'], button['v2'], button['v3']):
 
           print(f'Clicked on the {button['buttonName']} button')
 

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -16,11 +16,11 @@ def render_with_dictionary():
   # And also a 'key' which we use to retrieve them from their relevant list/dicts
 
   # Cells are in a dict - so follow this pattern
-  # BTW - not 100% sure why I used v3 here (maybe because highest point of the cell?)
+  # BTW - not 100% sure why I used v2 here (maybe because highest point of the cell?)
   all_elements = [{
     'type': 0,
     'key': n,
-    'coord': config.gameboard[n]['v3']
+    'coord': config.gameboard[n]['v2']
     } for n in config.cell_render_order
   ]
 
@@ -46,20 +46,28 @@ def render_with_dictionary():
       cell = config.gameboard[element['key']]
 
       # Rendering the walls of each cell
+      # Vertices need to cycle depending on which point of rotation we are at
+      # So doing some modular stuff to account for that
+      vertex_order = [
+        (3 - config.rotation_integer) % 4,
+        (0 - config.rotation_integer) % 4,
+        (1 - config.rotation_integer) % 4
+      ]
+
       glColor(0.5, 0.5, 0.5)
       glBegin(GL_POLYGON)
-      glVertex2f(*add_vectors(cell['v4'], [0, cell['height']], config.camera_offset))
-      glVertex2f(*add_vectors(cell['v4'], config.camera_offset))
-      glVertex2f(*add_vectors(cell['v1'], config.camera_offset))
-      glVertex2f(*add_vectors(cell['v2'], config.camera_offset))
-      glVertex2f(*add_vectors(cell['v2'], [0, cell['height']], config.camera_offset))
+      glVertex2f(*add_vectors(cell[f'v{vertex_order[0]}'], [0, cell['height']], config.camera_offset))
+      glVertex2f(*add_vectors(cell[f'v{vertex_order[0]}'], config.camera_offset))
+      glVertex2f(*add_vectors(cell[f'v{vertex_order[1]}'], config.camera_offset))
+      glVertex2f(*add_vectors(cell[f'v{vertex_order[2]}'], config.camera_offset))
+      glVertex2f(*add_vectors(cell[f'v{vertex_order[2]}'], [0, cell['height']], config.camera_offset))
       glEnd()
 
       # Rendering the actual cell surface
       glColor(*cell['color'])
       glBegin(GL_QUADS)
       for n in range(4):
-        glVertex2f(*add_vectors(cell[f'v{n + 1}'], [0, cell['height']], config.camera_offset))
+        glVertex2f(*add_vectors(cell[f'v{n}'], [0, cell['height']], config.camera_offset))
       glEnd()
 
       # Rendering the grid around the cell
@@ -67,7 +75,7 @@ def render_with_dictionary():
       glLineWidth(3) if config.interaction_cell == element['key'] else glLineWidth(0.5) # Thicker grid if mouse hover
       glBegin(GL_LINE_LOOP)
       for n in range(4):
-        glVertex2f(*add_vectors(cell[f'v{n + 1}'], [0, cell['height']], config.camera_offset))
+        glVertex2f(*add_vectors(cell[f'v{n}'], [0, cell['height']], config.camera_offset))
       glEnd()
 
       # OBJECT RENDERING
@@ -75,8 +83,8 @@ def render_with_dictionary():
       if cell['objectOnCell']:
 
         if cell['objectOnCell']['type'] == 'line':
-          start_vertex = find_vector_midpoint(cell['v4'], cell['v1'])
-          end_vertex = find_vector_midpoint(cell['v2'], cell['v3'])
+          start_vertex = find_vector_midpoint(cell['v3'], cell['v0'])
+          end_vertex = find_vector_midpoint(cell['v1'], cell['v2'])
 
           glColor(0, 0, 1)
           glLineWidth(3)
@@ -112,7 +120,7 @@ def render_hud():
     glColor(1, 0.7, 0.7) if config.user_data['mode'] == button['buttonName'] else glColor(1, 1, 1)
     glBegin(GL_QUADS)
     for n in range(4):
-      glVertex2f(*button[f'v{n + 1}'])
+      glVertex2f(*button[f'v{n}'])
     glEnd()
 
     # Render button outline
@@ -120,7 +128,7 @@ def render_hud():
     glLineWidth(0.5)
     glBegin(GL_LINE_LOOP)
     for n in range(4):
-      glVertex2f(*button[f'v{n + 1}'])
+      glVertex2f(*button[f'v{n}'])
     glEnd()
 
 
@@ -135,7 +143,7 @@ def render_popup_windows():
     glColor(window_to_render['color'])
     glBegin(GL_QUADS)
     for n in range(4):
-      glVertex2f(*window_to_render[f'v{n + 1}'])
+      glVertex2f(*window_to_render[f'v{n}'])
     glEnd()
 
     # Render each button + outline on top of the panel
@@ -144,12 +152,12 @@ def render_popup_windows():
       glColor(1, 1, 1)
       glBegin(GL_QUADS)
       for n in range(4):
-        glVertex2f(*button[f'v{n + 1}'])
+        glVertex2f(*button[f'v{n}'])
       glEnd()
 
       glColor(0.4, 0.4, 0.4)
       glLineWidth(0.5)
       glBegin(GL_LINE_LOOP)
       for n in range(4):
-        glVertex2f(*button[f'v{n + 1}'])
+        glVertex2f(*button[f'v{n}'])
       glEnd()


### PR DESCRIPTION
This is definitely the right way to do things. No doubt.

1. Rebase the cell vertices to start from 0. This makes them work MUCH better in base-4 arithmetic, allowing the % operator to work without a 'n + 1' in loops. This was long overdue.
2. Cell vertices are now static - that is, they don't get cycled in rotation. Means that I can directly reference cell vertices with objects on cell and they follow rotation properly. Lines placed on the board now rotate with the board - fantastic.
3. Cell walls need to be told which vertices to use in rendering - so I'm writing the vertex numbers into a list which subtract the rotation integer, in base-4 arithmetic. This cycles the vertices used in the opposite direction to the rotation.

All of these changes are necessary, I now realise. Rather fix them while you can.