### PR TITLE
Basic construction engine complete

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -53,7 +53,7 @@ popup_definition = [
     'name': 'constructPath',
     'buttons': [
       'left',
-      'forward',
+      'straight',
       'right'
     ]
   }, {

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -8,6 +8,14 @@ import config
 temp_cells_constructed_on = []
 temp_path = []
 
+# Might use this to decide directions for next construction block
+direction_mapper = [
+  (1, 0),
+  (0, 1),
+  (-1, 0),
+  (0, -1)
+]
+construction_direction = 0
 
 def place_first_piece_of_line():
 
@@ -35,8 +43,8 @@ def place_first_piece_of_line():
       (v4[1] + v1[1]) / 2
     ])
 
-    # Now dictate that the next cell being constructed on is x + 1 away from the interaction cell
-    config.construction_cell = tuple(add_vectors(config.interaction_cell, (1, 0)))
+    # Now dictate that the next cell being constructed on is x/y +- 1 away from the interaction cell
+    config.construction_cell = tuple(add_vectors(config.interaction_cell, direction_mapper[construction_direction]))
 
     # Let's see if any of that functionally worked...
     print(config.gameboard[config.interaction_cell])
@@ -47,22 +55,41 @@ def place_first_piece_of_line():
 
 
 # Pretty much the same pattern as above but with the construction_cell being used as reference rather than interaction_cell
-def place_next_piece_of_line():
+def place_next_piece_of_line(line_type, line_direction):
 
-  global temp_cells_constructed_on, temp_path
+  global temp_cells_constructed_on, temp_path, construction_direction
 
   if len(temp_cells_constructed_on) != 0:
 
+    # Line orientation == construction direction for left turns
+    # Line orientation == construction direction + 1 for right turns
+    # On the assumption that direction(0) = (1, 0) and rotates counterclockwise per each increment
+    # And orientation of the corner made by direction(0) -> direction(1) is also orientation(0), and also rotates counterclockwise
+    # Worst direction of that ever lmao, but draw it out on paper if you ever forget - that's how I just figured it out
+
+    if line_direction == 'left':
+      line_orientation = construction_direction
+      # Update the construction direction to reflect the direction provided in function
+      construction_direction = (construction_direction + 1) % 4
+    elif line_direction == 'right':
+      line_orientation = (1 + construction_direction) % 4
+      # Update the construction direction to reflect the direction provided in function
+      construction_direction = (construction_direction - 1) % 4
+    # else - drawing a straight line, which is trivially of orientation == direction
+    else:
+      line_orientation = construction_direction
+
     config.gameboard[config.construction_cell]['objectOnCell'] = {
-      'type': 'line',
-      'orientation': 1
+      'type': line_type,
+      'orientation': line_orientation
     }
 
     config.gameboard[config.construction_cell]['objectHeight'] = 0
 
     temp_cells_constructed_on.append(config.construction_cell)
 
-    config.construction_cell = tuple(add_vectors(config.construction_cell, [1, 0]))
+    # increment the construction cell to the next one
+    config.construction_cell = tuple(add_vectors(config.construction_cell, direction_mapper[construction_direction]))
 
     print(config.gameboard[config.construction_cell])
     print(temp_cells_constructed_on)

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -50,7 +50,7 @@ def place_first_piece_of_line():
 
 
 # Pretty much the same pattern as above but with the construction_cell being used as reference rather than interaction_cell
-def place_next_piece_of_line(line_type, line_direction):
+def place_next_piece_of_line(line_direction):
 
   global temp_cells_constructed_on, temp_path, construction_direction
 
@@ -63,17 +63,20 @@ def place_next_piece_of_line(line_type, line_direction):
     # Worst description of that ever lmao, but draw it out on paper if you ever forget - that's how I just figured it out
 
     if line_direction == 'left':
+      line_type = 'turn'
       line_orientation = construction_direction
       # Update the construction direction to reflect the direction provided in function
       construction_direction = (construction_direction + 1) % 4
 
     elif line_direction == 'right':
+      line_type = 'turn'
       line_orientation = (1 + construction_direction) % 4
       # Update the construction direction to reflect the direction provided in function
       construction_direction = (construction_direction - 1) % 4
 
     # else - drawing a straight line, which is trivially of orientation == direction
     else:
+      line_type = 'line'
       line_orientation = construction_direction
 
     config.gameboard[config.construction_cell]['objectOnCell'] = {

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -79,19 +79,25 @@ def place_next_piece_of_line(line_direction):
       line_type = 'line'
       line_orientation = construction_direction
 
+    # Adding the line object to the cell
     config.gameboard[config.construction_cell]['objectOnCell'] = {
       'type': line_type,
       'orientation': line_orientation
     }
-
+    # Specifying the height of the line object - 0 as placeholder
     config.gameboard[config.construction_cell]['objectHeight'] = 0
 
+    # Continuing to add to the list of cells constructed on - so we can wipe them out if exit partway through
     temp_cells_constructed_on.append(config.construction_cell)
+
+    # Adding the new point to the temp path
+    temp_path.append(find_vector_midpoint(config.gameboard[config.construction_cell]['v3'], config.gameboard[config.construction_cell]['v0']))
+
+    print(config.gameboard[config.construction_cell])
 
     # increment the construction cell to the next one
     config.construction_cell = tuple(add_vectors(config.construction_cell, direction_mapper[construction_direction]))
 
-    print(config.gameboard[config.construction_cell])
     print(temp_cells_constructed_on)
     print(temp_path)
     print(config.construction_cell)

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from .tools import add_vectors
+from .tools import add_vectors, find_vector_midpoint
 
 import config
 
@@ -27,7 +27,7 @@ def place_first_piece_of_line():
     # Add a line object to the cell being clicked on
     config.gameboard[config.interaction_cell]['objectOnCell'] = {
       'type': 'line',
-      'orientation': 1
+      'orientation': construction_direction
     }
 
     config.gameboard[config.interaction_cell]['objectHeight'] = 0
@@ -36,12 +36,7 @@ def place_first_piece_of_line():
     temp_cells_constructed_on.append(config.interaction_cell)
 
     # Write first coordinate to the temp object path
-    v4 = config.gameboard[config.interaction_cell]['v3']
-    v1 = config.gameboard[config.interaction_cell]['v0']
-    temp_path.append([
-      (v4[0] + v1[0]) / 2,
-      (v4[1] + v1[1]) / 2
-    ])
+    temp_path.append(find_vector_midpoint(config.gameboard[config.interaction_cell]['v3'], config.gameboard[config.interaction_cell]['v0']))
 
     # Now dictate that the next cell being constructed on is x/y +- 1 away from the interaction cell
     config.construction_cell = tuple(add_vectors(config.interaction_cell, direction_mapper[construction_direction]))
@@ -65,16 +60,18 @@ def place_next_piece_of_line(line_type, line_direction):
     # Line orientation == construction direction + 1 for right turns
     # On the assumption that direction(0) = (1, 0) and rotates counterclockwise per each increment
     # And orientation of the corner made by direction(0) -> direction(1) is also orientation(0), and also rotates counterclockwise
-    # Worst direction of that ever lmao, but draw it out on paper if you ever forget - that's how I just figured it out
+    # Worst description of that ever lmao, but draw it out on paper if you ever forget - that's how I just figured it out
 
     if line_direction == 'left':
       line_orientation = construction_direction
       # Update the construction direction to reflect the direction provided in function
       construction_direction = (construction_direction + 1) % 4
+
     elif line_direction == 'right':
       line_orientation = (1 + construction_direction) % 4
       # Update the construction direction to reflect the direction provided in function
       construction_direction = (construction_direction - 1) % 4
+
     # else - drawing a straight line, which is trivially of orientation == direction
     else:
       line_orientation = construction_direction

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -82,9 +82,9 @@ def mouse_click_mechanics(button, state, x, y):
 
       # ------------------------------------ TERRAFORMING ------------------------------------ #
 
-      elif config.user_data['mode'] == 'terraform':
+        elif config.user_data['mode'] == 'terraform':
         
-        is_dragging = True
+          is_dragging = True
     
     elif state == GLUT_UP:
       click_position = None

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -74,7 +74,7 @@ def mouse_click_mechanics(button, state, x, y):
         button = config.popup_windows[config.user_data['mode']]['buttons'][1]
 
         if is_point_in_quad((gl_x, gl_y), button['v0'], button['v1'], button['v2'], button['v3']):
-          place_next_piece_of_line('line', 'right')
+          place_next_piece_of_line('turn', 'left')
 
       # Then we check to see what mode we're in, and perform the respective actions
       if config.user_data['mode'] == 'constructPath':

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -69,17 +69,16 @@ def mouse_click_mechanics(button, state, x, y):
       # --------------------------------- CONSTRUCTION BUTTONS --------------------------------- #
 
       if config.user_data['mode']:
-        
-        # Just going to write in for the 'forward' button for now - to P the C if you will
-        button = config.popup_windows[config.user_data['mode']]['buttons'][1]
 
-        if is_point_in_quad((gl_x, gl_y), button['v0'], button['v1'], button['v2'], button['v3']):
-          place_next_piece_of_line('turn', 'left')
+        for button in config.popup_windows[config.user_data['mode']]['buttons']:
 
-      # Then we check to see what mode we're in, and perform the respective actions
-      if config.user_data['mode'] == 'constructPath':
+          if is_point_in_quad((gl_x, gl_y), button['v0'], button['v1'], button['v2'], button['v3']):
+            place_next_piece_of_line(button['name'])
 
-        place_first_piece_of_line()
+        # Then we check to see what mode we're in, and perform the respective actions
+        if config.user_data['mode'] == 'constructPath':
+
+          place_first_piece_of_line()
 
       # ------------------------------------ TERRAFORMING ------------------------------------ #
 

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -74,12 +74,14 @@ def mouse_click_mechanics(button, state, x, y):
         button = config.popup_windows[config.user_data['mode']]['buttons'][1]
 
         if is_point_in_quad((gl_x, gl_y), button['v0'], button['v1'], button['v2'], button['v3']):
-          place_next_piece_of_line()
-      
+          place_next_piece_of_line('line', 'right')
+
       # Then we check to see what mode we're in, and perform the respective actions
       if config.user_data['mode'] == 'constructPath':
 
         place_first_piece_of_line()
+
+      # ------------------------------------ TERRAFORMING ------------------------------------ #
 
       elif config.user_data['mode'] == 'terraform':
         

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -86,8 +86,13 @@ def render_with_dictionary():
       if cell['objectOnCell']:
 
         if cell['objectOnCell']['type'] == 'line':
-          start_vertex = find_vector_midpoint(cell['v3'], cell['v0'])
-          end_vertex = find_vector_midpoint(cell['v1'], cell['v2'])
+
+          # Getting the orientation of the line
+          orientation = cell['objectOnCell']['orientation']
+
+          # Dynamically pulling out the required vertices for the line, as per orientation
+          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation % 2) % 4}'], cell[f'v{(orientation % 2) % 4}'])
+          end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation % 2) % 4}'], cell[f'v{(2 + orientation % 2) % 4}'])
 
           glColor(0, 0, 1)
           glLineWidth(3)

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -95,6 +95,30 @@ def render_with_dictionary():
           glVertex2f(*add_vectors(start_vertex, [0, cell['height']], [0, cell['objectHeight']], config.camera_offset))
           glVertex2f(*add_vectors(end_vertex, [0, cell['height']], [0, cell['objectHeight']], config.camera_offset))
           glEnd()
+        
+        elif cell['objectOnCell']['type'] == 'turn':
+
+          orientation = cell['objectOnCell']['orientation']
+
+          # ORIENTATION INDEX:
+          # 0: (1, 0) -> (0, 1)     || mid(v3, v0) & mid(v2, v3)
+          # 1: (0, 1) -> (-1, 0)    || mid(v0, v1) & mid(v3, v0)
+          # 2: (-1, 0) -> (0, -1)   || mid(v1, v2) & mid(v0, v1)
+          # 3: (0, -1) -> (1, 0)    || mid(v2, v3) & mid(v1, v2)
+
+          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
+          end_vertex = find_vector_midpoint(cell[f'v{(2 + orientation) % 4}'], cell[f'v{(3 + orientation) % 4}'])
+
+          # Also need the midpoint - in order to do the 'turn' properly
+          centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
+
+          glColor(0, 0, 1)
+          glLineWidth(3)
+          glBegin(GL_LINE_STRIP)
+          glVertex2f(*add_vectors(start_vertex, [0, cell['height']], [0, cell['objectHeight']], config.camera_offset))
+          glVertex2f(*add_vectors(centre_vertex, [0, cell['height']], [0, cell['objectHeight']], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell['height']], [0, cell['objectHeight']], config.camera_offset))
+          glEnd()
 
     # Else, if they're an object...
     elif element['type'] == 1:

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -45,6 +45,8 @@ def render_with_dictionary():
     # If they're a cell...
     if element['type'] == 0:
       
+      # ------------------ GAME BOARD RENDERING (CELLS) ------------------ #
+
       # Then render a cell!
       cell = config.gameboard[element['key']]
 
@@ -81,7 +83,8 @@ def render_with_dictionary():
         glVertex2f(*add_vectors(cell[f'v{n}'], [0, cell['height']], config.camera_offset))
       glEnd()
 
-      # OBJECT RENDERING
+      # ------------------ STATIC OBJECT RENDERING ------------------ #
+
       # For now just going to render straight lines...
       if cell['objectOnCell']:
 
@@ -94,6 +97,7 @@ def render_with_dictionary():
           start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation % 2) % 4}'], cell[f'v{(orientation % 2) % 4}'])
           end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation % 2) % 4}'], cell[f'v{(2 + orientation % 2) % 4}'])
 
+          # Drawing the line
           glColor(0, 0, 1)
           glLineWidth(3)
           glBegin(GL_LINE_LOOP)
@@ -104,6 +108,9 @@ def render_with_dictionary():
         elif cell['objectOnCell']['type'] == 'turn':
 
           orientation = cell['objectOnCell']['orientation']
+
+          # Doing the same for the turns as the straight lines - though they're about a million times more complex lol
+          # So gonna write an index into the comments here to justify the madness inside the find_midpoint function calls
 
           # ORIENTATION INDEX:
           # 0: (1, 0) -> (0, 1)     || mid(v3, v0) & mid(v2, v3)
@@ -117,6 +124,7 @@ def render_with_dictionary():
           # Also need the midpoint - in order to do the 'turn' properly
           centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
 
+          # Drawing the corner
           glColor(0, 0, 1)
           glLineWidth(3)
           glBegin(GL_LINE_STRIP)


### PR DESCRIPTION
I really shouldn't have done all of this in a single PR... this is gonna be a NIGHTMARE to document hahahaha.


Ok so, the construction engine now has a 'construction_direction'. Defaults to 0, +1 if left turn, -1 if right turn, all in base 4 arithmetic. The integer in the 'construction_direction' variable maps to a unit vector in 'direction_mapper'. This unit vector is added to the 'construction_cell' after placement of a line segment, which allows for left/right turns to dictate the next cell properly.

construction_direction is ALSO being used as the line 'orientation' value, which is used to tell the renderer which direction to render the line in.
For straight sections, the orientation is just the construction direction.
For left/right turns, the orientation gets the +- 1 mentioned above.

Honestly, most of the rest of it is just mappings which I had to come up with lol. Tried to comment it as much as possible in-line, but it's not very easy. Reluctant to try typing it all.

------------------------

One thing that should probably be worked on in the near future, is the clicking of the popup buttons. Right now it's a bit of a weird generalised approach (whereby if a popup panel is clicked on then load the buttons in by popup name) but the rest of it is hardcoded to be construction-only.

This will probably be cleaned up naturally when I try to expand on the popup functionality (ie when I implement more terraforming options) but for now it works, and I'm keeping as is.

Hope I don't regret that lol.

------------------------

Next up: completing paths, writing them permanently, and running objects around them!