### PR TITLE
Generalising the 'popup' window functionality A LOT

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -58,8 +58,8 @@ popup_definition = [
   }, {
     'name': 'terraform',
     'buttons': [
-      'increase',
       'decrease',
+      'increase',
     ]
   }
 ]

--- a/src/config.py
+++ b/src/config.py
@@ -38,7 +38,7 @@ hud_icon_x = 0.07
 hud_icon_y = hud_icon_x * window_x / window_y
 
 # Actual HUD button array
-hud_buttons = build_hud(['terraform', 'constructPath'])
+hud_buttons = build_hud(['terraform', 'construct_path'])
 
 # Dictate which 'mode' the user is in
 user_data = {
@@ -49,7 +49,7 @@ user_data = {
 
 popup_definition = [
   {
-    'name': 'constructPath',
+    'name': 'construct_path',
     'buttons': [
       'left',
       'straight',
@@ -75,3 +75,10 @@ objects = []
 # NB: Might be able to get away w not putting this in the Config, but doing so for now
 
 construction_cell = None
+
+
+
+
+# TESTING SHIT
+
+terraform_scalar = 0

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -98,7 +98,7 @@ def place_first_piece_of_line():
 
 
 # Pretty much the same pattern as above but with the construction_cell being used as reference rather than interaction_cell
-def place_next_piece_of_line(line_direction):
+def construct_path_popup(action):
 
   global temp_cells_constructed_on, temp_path, construction_direction
 
@@ -112,13 +112,13 @@ def place_next_piece_of_line(line_direction):
     # And orientation of the corner made by direction(0) -> direction(1) is also orientation(0), and also rotates counterclockwise
     # Worst description of that ever lmao, but draw it out on paper if you ever forget - that's how I just figured it out
 
-    if line_direction == 'left':
+    if action == 'left':
       line_type = 'turn'
       line_orientation = construction_direction
       # Update the construction direction to reflect the direction provided in function
       construction_direction = (construction_direction + 1) % 4
 
-    elif line_direction == 'right':
+    elif action == 'right':
       line_type = 'turn'
       line_orientation = (1 + construction_direction) % 4
       # Update the construction direction to reflect the direction provided in function

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -2,9 +2,9 @@ from OpenGL.GL import *
 from OpenGL.GLUT import *
 from OpenGL.GLU import *
 
-from .construction import place_first_piece_of_line, construct_path_popup, kill_the_path_early
 from .tools import add_vectors, is_point_in_quad, normalise_pixel_coords
 from .terraform import *
+from .construction import *
 
 # LOADING IN ALL OUR SETUP VARIABLES
 import config
@@ -21,6 +21,7 @@ def mouse_hover_mechanics(x, y):
 
   config.interaction_cell = None
 
+  # Detecting hover over cell, storing the cell index if hovered
   for cell_index in config.cell_render_order:
 
     cell = config.gameboard[cell_index]
@@ -33,10 +34,10 @@ def mouse_hover_mechanics(x, y):
 
     if is_point_in_quad((gl_x, gl_y), v0, v1, v2, v3):
       
-      # config.interaction_cell = cell
       config.interaction_cell = cell_index
 
-# Handle the mouse clicking mechanics
+# --------------------------------- MOUSE CLICK MECHANICS --------------------------------- #
+
 def mouse_click_mechanics(button, state, x, y):
 
   global click_position, is_dragging
@@ -51,42 +52,27 @@ def mouse_click_mechanics(button, state, x, y):
       click_position = [gl_x, gl_y]
       print(f'Mouse Clicked at: {click_position}')
 
-      # --------------------------------- HUD BUTTONS --------------------------------- #
+      # ---- HUD Buttons ---- #
 
-      # First - are we clicking on a HUD button?
       for button_index in list(config.hud_buttons.keys()):
         button = config.hud_buttons[button_index]
 
+        # Check to see if user has clicked on a button
         if is_point_in_quad((gl_x, gl_y), button['v0'], button['v1'], button['v2'], button['v3']):
 
           print(f'Clicked on the {button['buttonName']} button')
 
-          # Below allows for toggling on buttons - if you're already in Terraform then exit Terraform
+          # If so - update the user 'mode' to reflect this
+          # Accounting for toggling - ie if user is in 'teraform' and clicks it again, then clear the mode
           if config.user_data['mode'] == button['buttonName']:
             config.user_data['mode'] = None
           else:
             config.user_data['mode'] = button['buttonName']
           
-      #     # Just dropping this in here - not the right place for it but who cares lol
-      #     kill_the_path_early()
+          # Placeholder to kill path construction early if HUD button is clicked
+          kill_the_path_early()
 
-      # --------------------------------- CONSTRUCTION BUTTONS --------------------------------- #
-
-      # if config.user_data['mode']:
-
-      #   for button in config.popup_windows[config.user_data['mode']]['buttons']:
-
-      #     if is_point_in_quad((gl_x, gl_y), button['v0'], button['v1'], button['v2'], button['v3']):
-      #       place_next_piece_of_line(button['name'])
-
-      # Then we check to see what mode we're in, and perform the respective actions
-      if config.user_data['mode'] == 'construct_path':
-        place_first_piece_of_line()
-
-
-      # --------------------------------- NEW SHIT --------------------------------- #
-
-      # POPUP BUTTONS
+      # ---- POPUP BUTTONS ---- #
 
       if config.user_data['mode']:
 
@@ -97,19 +83,19 @@ def mouse_click_mechanics(button, state, x, y):
 
             # Then perform the function dictated by {user mode}_popup, with the button name passed as argument
             globals()[f'{config.user_data['mode']}_popup'](button['name'])
+      
+      # ---- Bespoke actions ---- #
 
-      # ------------------------------------ TERRAFORMING ------------------------------------ #
-
-        # elif config.user_data['mode'] == 'terraform':
-        
-        #   is_dragging = True
+      if config.user_data['mode'] == 'construct_path': place_first_piece_of_line()
+      elif config.user_data['mode'] == 'terraform': is_dragging = True
     
     elif state == GLUT_UP:
       click_position = None
       is_dragging = False
       print(f'Mouse unclicked at: [{gl_x}, {gl_y}]')
 
-# Handle the mouse being click-dragged on screen
+# --------------------------------- MOUSE DRAG MECHANICS --------------------------------- #
+
 def mouse_drag_mechanics(x, y):
 
   global click_position, is_dragging

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -2,8 +2,9 @@ from OpenGL.GL import *
 from OpenGL.GLUT import *
 from OpenGL.GLU import *
 
-from .construction import place_first_piece_of_line, place_next_piece_of_line, kill_the_path_early
+from .construction import place_first_piece_of_line, construct_path_popup, kill_the_path_early
 from .tools import add_vectors, is_point_in_quad, normalise_pixel_coords
+from .terraform import *
 
 # LOADING IN ALL OUR SETUP VARIABLES
 import config
@@ -66,28 +67,42 @@ def mouse_click_mechanics(button, state, x, y):
           else:
             config.user_data['mode'] = button['buttonName']
           
-          # Just dropping this in here - not the right place for it but who cares lol
-          kill_the_path_early()
+      #     # Just dropping this in here - not the right place for it but who cares lol
+      #     kill_the_path_early()
 
       # --------------------------------- CONSTRUCTION BUTTONS --------------------------------- #
+
+      # if config.user_data['mode']:
+
+      #   for button in config.popup_windows[config.user_data['mode']]['buttons']:
+
+      #     if is_point_in_quad((gl_x, gl_y), button['v0'], button['v1'], button['v2'], button['v3']):
+      #       place_next_piece_of_line(button['name'])
+
+      # Then we check to see what mode we're in, and perform the respective actions
+      if config.user_data['mode'] == 'construct_path':
+        place_first_piece_of_line()
+
+
+      # --------------------------------- NEW SHIT --------------------------------- #
+
+      # POPUP BUTTONS
 
       if config.user_data['mode']:
 
         for button in config.popup_windows[config.user_data['mode']]['buttons']:
 
+          # If user has clicked on a button (by determining intersection with button vertices)...
           if is_point_in_quad((gl_x, gl_y), button['v0'], button['v1'], button['v2'], button['v3']):
-            place_next_piece_of_line(button['name'])
 
-        # Then we check to see what mode we're in, and perform the respective actions
-        if config.user_data['mode'] == 'constructPath':
-
-          place_first_piece_of_line()
+            # Then perform the function dictated by {user mode}_popup, with the button name passed as argument
+            globals()[f'{config.user_data['mode']}_popup'](button['name'])
 
       # ------------------------------------ TERRAFORMING ------------------------------------ #
 
-        elif config.user_data['mode'] == 'terraform':
+        # elif config.user_data['mode'] == 'terraform':
         
-          is_dragging = True
+        #   is_dragging = True
     
     elif state == GLUT_UP:
       click_position = None

--- a/src/functions/terraform.py
+++ b/src/functions/terraform.py
@@ -1,0 +1,13 @@
+import config
+
+
+def terraform_popup(action):
+
+  if action == 'increase': config.terraform_scalar += 1
+  elif action == 'decrease': config.terraform_scalar -= 1
+  
+  print(f'Terraform Scalar is {config.terraform_scalar}')
+
+def test_popup(action):
+
+  print(action)

--- a/src/functions/terraform.py
+++ b/src/functions/terraform.py
@@ -1,5 +1,6 @@
 import config
 
+# WAS JUST USING THIS TO TEST THE GENERALISED POPUP BUTTON FUNCTIONALITY
 
 def terraform_popup(action):
 
@@ -7,7 +8,3 @@ def terraform_popup(action):
   elif action == 'decrease': config.terraform_scalar -= 1
   
   print(f'Terraform Scalar is {config.terraform_scalar}')
-
-def test_popup(action):
-
-  print(action)


### PR DESCRIPTION
Today I learned how to call functions from text in Python!

And that's important, as I have now totally generalised the pattern for interacting with popups.

The pattern for popup button interaction is now as follows:

1. **Click detected on button**
2. Function is called, with the pattern f'{popup_name}_popup'(button_name) - that is, assume that each popup has a companion function, suffixed with '_popup', which can take the button names as arguments.

This is really sick, as it allows for massive scaling of popup window functionality.

As an example, the next feature I want to add is the ability to increase the terraforming cell hover spread. Now, to achieve this, I just need to define a function called terraform_popup(), which takes the arguments 'increase' or 'decrease', and all the mouse interaction will just work automatically.

SUPER SICK, NICE ONE.