### PR TITLE
Dev/increase hover spread in terraform mode

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -74,7 +74,7 @@ objects = []
 # ----------------------------------- CONSTRUCTION -----------------------------------
 # NB: Might be able to get away w not putting this in the Config, but doing so for now
 
-construction_cells = []
+construction_cell = None
 
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -29,7 +29,7 @@ rotation_integer = 0
 gameboard, cell_render_order = build_iso_gameboard()
 
 # Empty variable to store the value of the cell we are interacting with
-interaction_cell = None
+interaction_cells = []
 
 # ------------- HUD ------------- #
 
@@ -74,7 +74,7 @@ objects = []
 # ----------------------------------- CONSTRUCTION -----------------------------------
 # NB: Might be able to get away w not putting this in the Config, but doing so for now
 
-construction_cell = None
+construction_cells = []
 
 
 

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -30,7 +30,7 @@ def kill_the_path_early():
   # Then just reset all the construction vars back to default
   temp_cells_constructed_on = []
   temp_path = []
-  config.construction_cells = []
+  config.construction_cell = None
   construction_direction = 0
 
   print('PATH HAS BEEN TERMINATED EARLY')

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -30,7 +30,7 @@ def kill_the_path_early():
   # Then just reset all the construction vars back to default
   temp_cells_constructed_on = []
   temp_path = []
-  config.construction_cell = None
+  config.construction_cells = []
   construction_direction = 0
 
   print('PATH HAS BEEN TERMINATED EARLY')
@@ -73,27 +73,26 @@ def place_first_piece_of_line():
   if len(temp_cells_constructed_on) == 0:
 
     # Add a line object to the cell being clicked on
-    config.gameboard[config.interaction_cell]['objectOnCell'] = {
+    config.gameboard[config.interaction_cells[0]]['objectOnCell'] = {
       'type': 'line',
       'orientation': construction_direction
     }
 
-    config.gameboard[config.interaction_cell]['objectHeight'] = 0
+    config.gameboard[config.interaction_cells[0]]['objectHeight'] = 0
 
     # Log the clicked cell as the first cell being constructed on
-    temp_cells_constructed_on.append(config.interaction_cell)
+    temp_cells_constructed_on.append(config.interaction_cells[0])
 
     # Write first coordinate to the temp object path
-    temp_path.append(find_vector_midpoint(config.gameboard[config.interaction_cell]['v2'], config.gameboard[config.interaction_cell]['v0']))
+    temp_path.append(find_vector_midpoint(config.gameboard[config.interaction_cells[0]]['v2'], config.gameboard[config.interaction_cells[0]]['v0']))
 
     # Now dictate that the next cell being constructed on is x/y +- 1 away from the interaction cell
-    config.construction_cell = tuple(add_vectors(config.interaction_cell, direction_mapper[construction_direction]))
+    config.construction_cell = tuple(add_vectors(config.interaction_cells[0], direction_mapper[construction_direction]))
 
     # Let's see if any of that functionally worked...
-    print(config.gameboard[config.interaction_cell])
     print(temp_cells_constructed_on)
     print(temp_path)
-    print(f'Interaction Cell index is: {config.interaction_cell}')
+    print(f'Interaction Cell index is: {config.interaction_cells[0]}')
     print(f'Construction Cell index is: {config.construction_cell}')
 
 

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -19,22 +19,33 @@ def mouse_hover_mechanics(x, y):
   # Convert pixel coords to normalised (-1, 1) coords
   gl_x, gl_y = normalise_pixel_coords(x, y)
 
-  config.interaction_cell = None
+  # This line is necessary to clear the hovered cells when the mouse leaves the gameboard
+  config.interaction_cells = []
 
-  # Detecting hover over cell, storing the cell index if hovered
-  for cell_index in config.cell_render_order:
+  # Only show hovered cells if an interaction mode is selected
+  if config.user_data['mode']:
 
-    cell = config.gameboard[cell_index]
+    # Detecting hover over cell, storing the cell index if hovered
+    for cell_index in config.cell_render_order:
 
-    # Preparing cell vertices for area intersection detection
-    v0 = add_vectors(cell['v0'], [0, cell['height']], config.camera_offset)
-    v1 = add_vectors(cell['v1'], [0, cell['height']], config.camera_offset)
-    v2 = add_vectors(cell['v2'], [0, cell['height']], config.camera_offset)
-    v3 = add_vectors(cell['v3'], [0, cell['height']], config.camera_offset)
+      cell = config.gameboard[cell_index]
 
-    if is_point_in_quad((gl_x, gl_y), v0, v1, v2, v3):
-      
-      config.interaction_cell = cell_index
+      # Preparing cell vertices for area intersection detection
+      v0 = add_vectors(cell['v0'], [0, cell['height']], config.camera_offset)
+      v1 = add_vectors(cell['v1'], [0, cell['height']], config.camera_offset)
+      v2 = add_vectors(cell['v2'], [0, cell['height']], config.camera_offset)
+      v3 = add_vectors(cell['v3'], [0, cell['height']], config.camera_offset)
+
+      if is_point_in_quad((gl_x, gl_y), v0, v1, v2, v3):
+
+        cells_hovered = []
+
+        for x in range(config.terraform_scalar + 1):
+          for y in range(config.terraform_scalar + 1):
+            # NB: the // division is to offset the cells hovered such that the curser is always in the middle of the spread
+            cells_hovered.append((cell_index[0] + x - (config.terraform_scalar // 2), cell_index[1] + y - (config.terraform_scalar // 2)))
+
+        config.interaction_cells = cells_hovered
 
 # --------------------------------- MOUSE CLICK MECHANICS --------------------------------- #
 

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -81,7 +81,10 @@ def mouse_click_mechanics(button, state, x, y):
             config.user_data['mode'] = button['buttonName']
           
           # Placeholder to kill path construction early if HUD button is clicked
+          # And to reset the terraform scalar
+          # I need to find a better place to put these man...
           kill_the_path_early()
+          config.terraform_scalar = 0
 
       # ---- POPUP BUTTONS ---- #
 
@@ -125,5 +128,6 @@ def mouse_drag_mechanics(x, y):
 
       # Then update the height of the cell!
       # config.interaction_cell['height'] += units_dragged
-      config.gameboard[config.interaction_cell]['height'] += units_dragged
+      for cell_index in config.interaction_cells:
+        config.gameboard[cell_index]['height'] += units_dragged
       click_position = [gl_x, gl_y]

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -77,7 +77,7 @@ def render_with_dictionary():
 
       # Rendering the grid around the cell
       glColor(0, 0, 1, 0.5)
-      glLineWidth(3) if element['key'] in config.construction_cells + config.interaction_cells else glLineWidth(0.5) # Thicker grid if mouse hover
+      glLineWidth(3) if element['key'] in [config.construction_cell] + config.interaction_cells else glLineWidth(0.5) # Thicker grid if mouse hover
       glBegin(GL_LINE_LOOP)
       for n in range(4):
         glVertex2f(*add_vectors(cell[f'v{n}'], [0, cell['height']], config.camera_offset))

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -77,7 +77,7 @@ def render_with_dictionary():
 
       # Rendering the grid around the cell
       glColor(0, 0, 1, 0.5)
-      glLineWidth(3) if element['key'] in [config.construction_cell, config.interaction_cell] else glLineWidth(0.5) # Thicker grid if mouse hover
+      glLineWidth(3) if element['key'] in config.construction_cells + config.interaction_cells else glLineWidth(0.5) # Thicker grid if mouse hover
       glBegin(GL_LINE_LOOP)
       for n in range(4):
         glVertex2f(*add_vectors(cell[f'v{n}'], [0, cell['height']], config.camera_offset))

--- a/src/functions/terraform.py
+++ b/src/functions/terraform.py
@@ -5,6 +5,7 @@ import config
 def terraform_popup(action):
 
   if action == 'increase': config.terraform_scalar += 1
-  elif action == 'decrease': config.terraform_scalar -= 1
+  # Only decrease to 0 as minimum
+  elif action == 'decrease': config.terraform_scalar = max(config.terraform_scalar - 1, 0)
   
   print(f'Terraform Scalar is {config.terraform_scalar}')


### PR DESCRIPTION
[[ ACTUAL PR HERE - MERGED LAST ONE INTO MASTER BY ACCIDENT GOODNESS ME ]]

Small addition, though with a pretty big fundamental engine change.

So naturally, in order to increase my 'interaction cell' count, this needed to change to store a list of tuples rather than a single tuple. That way if the 'terraform_scalar' increases, the mouse hover mechanic can store multiple cell references at a time to be modified.

This is achieved by simulating a 'squaring' action on the terraform_scalar. Basically just two nested For loops, which incrementally increase the hovered cell index tuple, and store it in the interaction_cells array of tuples. Basically allow for adjacent cells up to a specified magnitude to be stored for rendering/modification.

This then meant that anything which references config.interaction_cell had to be changed to config.interaction_cells[0], as it is implied that this is now an Array.

However, in terraforming, the act of increasing a cell height now needs to be nested within a loop, whereby each cell index in config.interaction_cells has the height changed.

Also needed to change the rendering for the hovered cell outline a little bit, since this was also expecting a single tuple, rather than an array of them.

I will update all the inline comments accordingly before I merge this back into Master. Nothing huge is different, but it's a bit of a fundamental mechanic change which I may not have accounted for in my previous notes.

SHES GETTING COMPLICATED BABY!!!!