### PR TITLE
Terraforming now brings selected cells up/down to the min/max height of selected cells

### DIFF
--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -129,5 +129,5 @@ def mouse_drag_mechanics(x, y):
       # Then update the height of the cell!
       # config.interaction_cell['height'] += units_dragged
       for cell_index in config.interaction_cells:
-        config.gameboard[cell_index]['height'] += units_dragged
+        config.gameboard[cell_index]['height'] = max(config.gameboard[cell_index]['height'] + units_dragged, config.unit_height)
       click_position = [gl_x, gl_y]

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -95,7 +95,7 @@ def mouse_click_mechanics(button, state, x, y):
           # If user has clicked on a button (by determining intersection with button vertices)...
           if is_point_in_quad((gl_x, gl_y), button['v0'], button['v1'], button['v2'], button['v3']):
 
-            # Then perform the function dictated by {user mode}_popup, with the button name passed as argument
+            # Then perform the function dictated by f'{user mode}_popup', with the button name passed as argument
             globals()[f'{config.user_data['mode']}_popup'](button['name'])
       
       # ---- Bespoke actions ---- #
@@ -127,7 +127,7 @@ def mouse_drag_mechanics(x, y):
     if units_dragged != 0:
 
       # Then update the height of the cell!
-      # config.interaction_cell['height'] += units_dragged
-      for cell_index in config.interaction_cells:
-        config.gameboard[cell_index]['height'] = max(config.gameboard[cell_index]['height'] + units_dragged, config.unit_height)
+      terraform_cells(units_dragged)
+
+      # And finally, update the base position - this allows for continuous motion, instead of just updating on mouse release
       click_position = [gl_x, gl_y]

--- a/src/functions/terraform.py
+++ b/src/functions/terraform.py
@@ -1,6 +1,8 @@
 import config
 
-# WAS JUST USING THIS TO TEST THE GENERALISED POPUP BUTTON FUNCTIONALITY
+# TERRAFORM POPUP
+# Note that the below is following a generalised popup pattern, whereby the function name has to be 'mode'_popup(action)
+# This keeps all popup management very simple
 
 def terraform_popup(action):
 
@@ -9,3 +11,24 @@ def terraform_popup(action):
   elif action == 'decrease': config.terraform_scalar = max(config.terraform_scalar - 1, 0)
   
   print(f'Terraform Scalar is {config.terraform_scalar}')
+
+
+# The actual function to drag the cells up and down
+# Yeah we're modularising things baby!!
+
+def terraform_cells(units_dragged):
+
+  # First, let's store the min and max heights of the land being dragged
+  cell_heights = [config.gameboard[cell_index]['height'] for cell_index in config.interaction_cells]
+  min_cell_height = min(cell_heights); max_cell_height = max(cell_heights)
+
+  for cell_index in config.interaction_cells:
+
+    if (
+       # Positive units_dragged should only affect cells with height equal to the minimum height
+      (units_dragged > 0 and config.gameboard[cell_index]['height'] == min_cell_height)
+      or
+      # Conversely, negative units_dragged should do the same with maximum height``
+      (units_dragged < 0 and config.gameboard[cell_index]['height'] == max_cell_height)
+    ):
+        config.gameboard[cell_index]['height'] = max(config.gameboard[cell_index]['height'] + units_dragged, config.unit_height)


### PR DESCRIPTION
Pretty small, but doing so I don't have to write a narrative for every damn PR.

Basically have just made terraforming a lot more like RCT now, whereby the tool can be used to bring land up/down to uniform heights.

Previously, starting height of all selected cells would be honoured in future terraforming - that is, if one cell is higher than the rest, then it'll continue being higher throughout the movement. This makes unifying cell heights very time consuming. One of the many things Mr Sawyer got completely right in his engine.

This turned out being a lot easier than expected. Just a couple quick if conditions, and a 'max' function to stop the gameboard from ever being dragged below its base height.

Look at the code if you wanna see more, but honestly not much to say here!