### PR TITLE
First piece of line can now be rotated

### DIFF
--- a/src/functions/camera_operations.py
+++ b/src/functions/camera_operations.py
@@ -21,47 +21,45 @@ def move_camera(key):
     config.camera_offset[0] -= (config.unit_width ** 2) * (1 / 2)
 
 # Using the spacebar to rotate the camera 90 degrees counterclockwise
-def rotate_camera(key):
+def rotate_camera():
 
-  if key == b' ':
+  print('Starting rotation')
 
-    print('Starting rotation')
+  # ROTATION IS TRICKY - BUT THIS IS HOW IT NEEDS TO BE DONE
+  # As it is infinitely better to store the coords as iso in the gameboard var, rather than convert on every frame render
 
-    # ROTATION IS TRICKY - BUT THIS IS HOW IT NEEDS TO BE DONE
-    # As it is infinitely better to store the coords as iso in the gameboard var, rather than convert on every frame render
+  for cell_index in config.cell_render_order:
 
-    for cell_index in config.cell_render_order:
+    # Retrieve the cell from the dictionary using the cell index
+    cell = config.gameboard[cell_index]
 
-      # Retrieve the cell from the dictionary using the cell index
-      cell = config.gameboard[cell_index]
+    for n in range(4):
 
-      for n in range(4):
+      iso_x, iso_y = rotate_coordinates(*cell[f'v{n}'])
 
-        iso_x, iso_y = rotate_coordinates(*cell[f'v{n}'])
-
-        cell[f'v{n}'][0] = iso_x
-        cell[f'v{n}'][1] = iso_y
+      cell[f'v{n}'][0] = iso_x
+      cell[f'v{n}'][1] = iso_y
     
-    # Also need to rotate all the object paths and current positions
-    for object in config.objects:
+  # Also need to rotate all the object paths and current positions
+  for object in config.objects:
 
-      # Approach for this (since is a list) is to just append a new blank list then overwrite the old one
-      rotated_path = []
-      for n in range(len(object['path'])):
-        rotated_path.append(rotate_coordinates(*object['path'][n]))
+    # Approach for this (since is a list) is to just append a new blank list then overwrite the old one
+    rotated_path = []
+    for n in range(len(object['path'])):
+      rotated_path.append(rotate_coordinates(*object['path'][n]))
       
-      object['path'] = rotated_path
+    object['path'] = rotated_path
 
-      # Now do the Current Position as well
-      object['lastKnownPosition'] = rotate_coordinates(*object['lastKnownPosition'])
+    # Now do the Current Position as well
+    object['lastKnownPosition'] = rotate_coordinates(*object['lastKnownPosition'])
     
-    # Need to run a full rotation pattern on the camera_offset config variable too
-    config.camera_offset = [*rotate_coordinates(*config.camera_offset)]
+  # Need to run a full rotation pattern on the camera_offset config variable too
+  config.camera_offset = [*rotate_coordinates(*config.camera_offset)]
     
-    # Update the rotation integer to tell game which sprites to render
-    config.rotation_integer = (config.rotation_integer + 1) % 4
+  # Update the rotation integer to tell game which sprites to render
+  config.rotation_integer = (config.rotation_integer + 1) % 4
     
-    # Now, in order for rendering to work, we need to sort the 'render order' array, in descending Y, then descending X within
-    config.cell_render_order = sorted(config.gameboard.keys(), key = lambda t: (config.gameboard[t]['v0'][1], config.gameboard[t]['v0'][0]), reverse = True)
-    print('Rotation complete')
-    print(f'Now rendering sprites of rotation integer {config.rotation_integer}')
+  # Now, in order for rendering to work, we need to sort the 'render order' array, in descending Y, then descending X within
+  config.cell_render_order = sorted(config.gameboard.keys(), key = lambda t: (config.gameboard[t]['v0'][1], config.gameboard[t]['v0'][0]), reverse = True)
+  print('Rotation complete')
+  print(f'Now rendering sprites of rotation integer {config.rotation_integer}')

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -15,6 +15,18 @@ direction_mapper = [
 ]
 construction_direction = 0
 
+# Use the 'z' key to rotate the orientation of the starting line
+def rotate_starting_piece():
+
+  global construction_direction
+
+  # Only perform rotation if we're in construct_path mode, and we haven't built any line segments yet
+  if config.user_data['mode'] == 'construct_path' and len(temp_cells_constructed_on) == 0:
+    # Keep it in base 4 arithmetic please!!!
+    construction_direction = (construction_direction + 1) % 4
+    
+    print(f'Initial piece orientation has changed to: {construction_direction}')
+
 # Logic for not finishing the path - if the user clicks on one of the other HUD buttons before completion
 def kill_the_path_early():
 

--- a/src/functions/input.py
+++ b/src/functions/input.py
@@ -4,6 +4,7 @@ from OpenGL.GLU import *
 
 from .camera_operations import move_camera, rotate_camera
 from .mouse_operations import mouse_hover_mechanics, mouse_click_mechanics, mouse_drag_mechanics
+from .construction import rotate_starting_piece
 
 # 'Special' keys here - such as arrow keys, anything non-alphanumeric basically
 def special_keys(key, x, y):
@@ -15,7 +16,13 @@ def special_keys(key, x, y):
 # 'Normal' keys here - think alphanumeric type beat
 def normal_keys(key, x, y):
 
-  rotate_camera(key)
+  # Rotate camera
+  if key == b' ':
+    rotate_camera()
+
+  # Rotate first piece of line construction
+  elif key == b'z':
+    rotate_starting_piece()
   
   glutPostRedisplay()
 

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -100,7 +100,7 @@ def mouse_click_mechanics(button, state, x, y):
       
       # ---- Bespoke actions ---- #
 
-      if config.user_data['mode'] == 'construct_path': place_first_piece_of_line()
+      if config.user_data['mode'] == 'construct_path' and config.interaction_cells: place_first_piece_of_line()
       elif config.user_data['mode'] == 'terraform': is_dragging = True
     
     elif state == GLUT_UP:


### PR DESCRIPTION
Nice easy one to start this feature branch. It looks like there are a lot of changes but most of them are just undoing indentations from a removed 'if' statement hahaha.

First piece of line can now be rotated by pressing the 'z' key. Only works if the user is in 'construct_line' mode and there are no existing temp_cells_constructed_on tuples stored.

Have made some light modification to the input.py file to account for this, as I was previously only accounting for spacebars to rotate the camera orientation. Figure not a bad idea to put the key recognition into this file, as it's been pretty much redundant up until this point lol. May as well use it for something.

SIDE NOTE: ALSO FIXED A VERY SMALL PROBLEM WHERE THE GAME WAS ATTEMPTING TO BUILD A LINE IMMEDIATELY AFTER THE CONSTRUCT_LINE MODE HAS BEEN ENTERED. This place_first_line() function now only runs if there exists an interaction_cells object to run it on.

Funny enough, when run on Windows, this problem crashed the whole thing - whereas on UNIX it keeps the game running, just errors the Terminal running it. Which is better? Who knows...