### PR TITLE
Path coordinates now map correctly if camera is rotated mid-construction

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -73,8 +73,11 @@ objects = []
 
 # ----------------------------------- CONSTRUCTION -----------------------------------
 # NB: Might be able to get away w not putting this in the Config, but doing so for now
+# UPDATE: CANT GET AWAY WITH NOT PUTTING IT IN THE CONFIG - AS NEED TO ROTATE PATH COORDS WITH CAMERA ROTATION
 
 construction_cell = None
+temp_cells_constructed_on = []
+temp_path = []
 
 
 

--- a/src/functions/camera_operations.py
+++ b/src/functions/camera_operations.py
@@ -52,6 +52,12 @@ def rotate_camera():
 
     # Now do the Current Position as well
     object['lastKnownPosition'] = rotate_coordinates(*object['lastKnownPosition'])
+  
+  # ALSO need to rotate any coordinates stored in a temporary path - oh my lord
+  rotated_temp_path = []
+  for path_point in config.temp_path:
+    rotated_temp_path.append(rotate_coordinates(*path_point))
+  config.temp_path = rotated_temp_path
     
   # Need to run a full rotation pattern on the camera_offset config variable too
   config.camera_offset = [*rotate_coordinates(*config.camera_offset)]


### PR DESCRIPTION
Speed running features!!!

Had a small issue where rotation of camera mid-construction wasn't rotating the temp_path coordinates - so the dot path would go way out of whack.

Simple fix - just include temp_path in the list of things re-mapped in the camera_rotation action.

In the process of this I had to move the temp_path array to the config.py file. Is what it is. Also moved the temp_cells_constructed_on to the config as well. I know it will likely never need to be there, but frick it man why not. We were already overhauling all the temp_path calls in the file anyways.

I should really do some research around how these things are *supposed* to be set up. I feel like my config file is getting a little bit large hahahaha.

Still having fun though!