### PR TITLE
Path construction now fully accounts for z-axis heights

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -78,6 +78,7 @@ objects = []
 construction_cell = None
 temp_cells_constructed_on = []
 temp_path = []
+temp_height = []
 
 
 

--- a/src/functions/camera_operations.py
+++ b/src/functions/camera_operations.py
@@ -2,7 +2,7 @@ from OpenGL.GL import *
 from OpenGL.GLUT import *
 from OpenGL.GLU import *
 
-from .tools import rotate_coordinates
+from .tools import rotate_coordinates, rotate_coordinates_with_height_component
 
 # LOADING IN ALL OUR SETUP VARIABLES
 import config
@@ -41,22 +41,27 @@ def rotate_camera():
       cell[f'v{n}'][1] = iso_y
     
   # Also need to rotate all the object paths and current positions
+  # KEEPING IN MIND YOU NEED TO TRANSFORM THE PATHS AND POSITIONS BY THEIR HEIGHTS FIRST
+  # Because iso coordinates are hard
   for object in config.objects:
 
     # Approach for this (since is a list) is to just append a new blank list then overwrite the old one
     rotated_path = []
     for n in range(len(object['path'])):
-      rotated_path.append(rotate_coordinates(*object['path'][n]))
+      # Rotation needs to be around the projection of an object to the grid base - so need to call a 'height component' rotation function
+      rotated_path.append(rotate_coordinates_with_height_component(*object['path'][n], object['height'][n]))
       
     object['path'] = rotated_path
 
     # Now do the Current Position as well
-    object['lastKnownPosition'] = rotate_coordinates(*object['lastKnownPosition'])
+    # Rotation needs to be around the projection of an object to the grid base - so need to call a 'height component' rotation function
+    object['lastKnownPosition'] = rotate_coordinates_with_height_component(*object['lastKnownPosition'], object['lastKnownHeight'])
   
   # ALSO need to rotate any coordinates stored in a temporary path - oh my lord
   rotated_temp_path = []
-  for path_point in config.temp_path:
-    rotated_temp_path.append(rotate_coordinates(*path_point))
+  for n in range(len(config.temp_path)):
+    # Rotation needs to be around the projection of an object to the grid base - so need to call a 'height component' rotation function
+    rotated_temp_path.append(rotate_coordinates_with_height_component(*config.temp_path[n], config.temp_height[n]))
   config.temp_path = rotated_temp_path
     
   # Need to run a full rotation pattern on the camera_offset config variable too

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -38,6 +38,7 @@ def kill_the_path_early():
   # Then just reset all the construction vars back to default
   config.temp_cells_constructed_on = []
   config.temp_path = []
+  config.temp_height = []
   config.construction_cell = None
   construction_direction = 0
 
@@ -58,7 +59,7 @@ def complete_line_construction():
     'name': 'object1',
     'color': (1, 0, 0),
     'path': config.temp_path,
-    'height': config.unit_height,
+    'height': config.temp_height,
     'speed': 0.2,
     'lastKnownSegment': 0,
     'lastKnownPosition': config.temp_path[0]
@@ -66,6 +67,7 @@ def complete_line_construction():
 
   config.temp_path = []
   config.temp_cells_constructed_on = []
+  config.temp_height = []
   config.construction_cell = None
   config.user_data['mode'] = None
   construction_direction = 0
@@ -90,7 +92,15 @@ def place_first_piece_of_line():
     config.temp_cells_constructed_on.append(config.interaction_cells[0])
 
     # Write first coordinate to the temp object path
-    config.temp_path.append(find_vector_midpoint(config.gameboard[config.interaction_cells[0]]['v2'], config.gameboard[config.interaction_cells[0]]['v0']))
+    config.temp_path.append(
+      find_vector_midpoint(
+        add_vectors(config.gameboard[config.interaction_cells[0]]['v2'], [0, config.gameboard[config.interaction_cells[0]]['height']]),
+        add_vectors(config.gameboard[config.interaction_cells[0]]['v0'], [0, config.gameboard[config.interaction_cells[0]]['height']])
+      )
+    )
+
+    # Write cell height to temp height array
+    config.temp_height.append(config.gameboard[config.interaction_cells[0]]['height'])
 
     # Now dictate that the next cell being constructed on is x/y +- 1 away from the interaction cell
     config.construction_cell = tuple(add_vectors(config.interaction_cells[0], direction_mapper[construction_direction]))
@@ -146,7 +156,15 @@ def construct_path_popup(action):
     config.temp_cells_constructed_on.append(config.construction_cell)
 
     # Adding the new point to the temp path
-    config.temp_path.append(find_vector_midpoint(config.gameboard[config.construction_cell]['v2'], config.gameboard[config.construction_cell]['v0']))
+    config.temp_path.append(
+      find_vector_midpoint(
+        add_vectors(config.gameboard[config.construction_cell]['v2'], [0, config.gameboard[config.construction_cell]['height']]),
+        add_vectors(config.gameboard[config.construction_cell]['v0'], [0, config.gameboard[config.construction_cell]['height']])
+      )
+    )
+
+    # Write cell height to temp height array
+    config.temp_height.append(config.gameboard[config.construction_cell]['height'])
 
     print(config.gameboard[config.construction_cell])
 

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -62,7 +62,8 @@ def complete_line_construction():
     'height': config.temp_height,
     'speed': 0.2,
     'lastKnownSegment': 0,
-    'lastKnownPosition': config.temp_path[0]
+    'lastKnownPosition': config.temp_path[0],
+    'lastKnownHeight': config.temp_height[0]
   })
 
   config.temp_path = []

--- a/src/functions/object_movement.py
+++ b/src/functions/object_movement.py
@@ -15,13 +15,16 @@ def update_object_positions():
         # Store the stuff I need - just makes the next steps easier
         current_position = object['lastKnownPosition']
         current_segment = object['lastKnownSegment']
+        current_height = object['lastKnownHeight']
         path = object['path']
+        height_path = object['height']
         speed = object['speed']
         n_points = len(path)
 
 
         # First, let's see if this object needs to be rendered on the next path segment
         dist_left_current_segment = get_magnitude(current_position, path[(current_segment + 1) % n_points])
+        height_change_left_current_segment = height_path[(current_segment + 1) % n_points] - current_height
         dist_to_travel = (time() - last_snapped_time) * speed
 
         # Case 1: this increment will keep the object along the current path segment
@@ -31,6 +34,8 @@ def update_object_positions():
                 current_position[0] + unit_vector[0] * dist_to_travel,
                 current_position[1] + unit_vector[1] * dist_to_travel
             ]
+            # Incrementing height by the % of the path left which is being travelled
+            object['lastKnownHeight'] += height_change_left_current_segment * (dist_to_travel / dist_left_current_segment)
         
         # Case 2: this increment completes a segment and needs to roll to the next one
         else:
@@ -47,6 +52,10 @@ def update_object_positions():
                 next_segment_start[0] + unit_vector[0] * dist_to_travel,
                 next_segment_start[1] + unit_vector[1] * dist_to_travel,
             ]
+            # In order to do height, need to calculate % of next path we are going to travel, and apply to the height delta
+            dist_next_segment = get_magnitude(next_segment_start, path[(current_segment + 1) % n_points])
+            height_change_next_segment = height_path[(current_segment + 1) % n_points] - height_path[current_segment]
+            object['lastKnownHeight'] = height_path[current_segment] + height_change_next_segment * (dist_to_travel / dist_next_segment)
 
             # Update object to ensure it knows it's on the next segment
             object['lastKnownSegment'] = current_segment

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -33,7 +33,7 @@ def render_with_dictionary():
     all_elements.append({
       'type': 1,
       'key': n,
-      'coord': config.objects[n]['lastKnownPosition']
+      'coord': add_vectors(config.objects[n]['lastKnownPosition'], [0, -config.objects[n]['lastKnownHeight']])
     })
 
   # Sort em all!!

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -153,10 +153,10 @@ def render_with_dictionary():
       # For now I'm just rendering a super basic quad around a point - just to PoC this
       glColor(*object['color'])
       glBegin(GL_QUADS)
-      glVertex2f(*add_vectors(object['lastKnownPosition'], [-0.01, -0.01], [0, object['height']], config.camera_offset))
-      glVertex2f(*add_vectors(object['lastKnownPosition'], [0.01, -0.01], [0, object['height']], config.camera_offset))
-      glVertex2f(*add_vectors(object['lastKnownPosition'], [0.01, 0.01], [0, object['height']], config.camera_offset))
-      glVertex2f(*add_vectors(object['lastKnownPosition'], [-0.01, 0.01], [0, object['height']], config.camera_offset))
+      glVertex2f(*add_vectors(object['lastKnownPosition'], [-0.01, -0.01], config.camera_offset))
+      glVertex2f(*add_vectors(object['lastKnownPosition'], [0.01, -0.01], config.camera_offset))
+      glVertex2f(*add_vectors(object['lastKnownPosition'], [0.01, 0.01], config.camera_offset))
+      glVertex2f(*add_vectors(object['lastKnownPosition'], [-0.01, 0.01], config.camera_offset))
       glEnd()
 
 

--- a/src/functions/tools.py
+++ b/src/functions/tools.py
@@ -1,5 +1,20 @@
 import config
 
+
+# I have no reason to need these - but might be useful
+def add_vectors(v1, v2, v3 = [0, 0], v4 = [0, 0]):
+  return [
+    v1[0] + v2[0] + v3[0] + v4[0],
+    v1[1] + v2[1] + v3[1] + v4[1]
+  ]
+
+def multiply_vectors(v1, v2, v3 = [0, 0]):
+
+  return [
+    v1[0] * v2[0] * v3[0],
+    v1[1] * v2[1] * v3[1]
+  ]
+
 # Translate cartesian coordinates to isometric coordinates
 def iso_translater(x, y):
 
@@ -28,6 +43,18 @@ def rotate_coordinates(iso_x, iso_y):
   iso_x_rotated, iso_y_rotated = iso_translater(cart_x, cart_y)
 
   return iso_x_rotated, iso_y_rotated
+
+# Because everything in iso coords is based on a base grid, object coordinates need to have height removed and readded pre + post rotation
+def rotate_coordinates_with_height_component(iso_x, iso_y, height):
+
+  # Subtract height to project to grid coordinates
+  grid_projected_coords = add_vectors([iso_x, iso_y], [0, -height])
+  # Rotate the grid-projected coordinates
+  rotated_projected_x, rotated_projected_y = rotate_coordinates(*grid_projected_coords)
+  # Re-add the height back to the projected coordinates
+  rotated_final_coords = add_vectors([rotated_projected_x, rotated_projected_y], [0, height])
+  
+  return rotated_final_coords[0], rotated_final_coords[1]
 
 # Convert pixel coordinates to normalised OpenGL coordinates (between -1 and 1 on both axes)
 def normalise_pixel_coords(x, y):
@@ -80,17 +107,5 @@ def find_vector_midpoint(v1, v2):
   ]
 
 
-# I have no reason to need these - but might be useful
-def add_vectors(v1, v2, v3 = [0, 0], v4 = [0, 0]):
-  return [
-    v1[0] + v2[0] + v3[0] + v4[0],
-    v1[1] + v2[1] + v3[1] + v4[1]
-  ]
 
-def multiply_vectors(v1, v2, v3 = [0, 0]):
-
-  return [
-    v1[0] * v2[0] * v3[0],
-    v1[1] * v2[1] * v3[1]
-  ]
 


### PR DESCRIPTION
Honestly, this is insane. Can't believe I just sat down and came up with this, what on earth.

OK SO, the initial idea was simple - add the cell_height to the path coordinates. That means that the path is the TRUE path of the object, rather than the path on the gameboard plus heights. This has a major advantage of keeping speed consistent on incline/declines, as there is more actual distance to travel.

THE BAD NEWS FROM THIS, though, is that this totally cooks the rendering order. Rendering works by sorting all cells + objects based on their coordinates, ON THE ASSUMPTION THAT THEY ARE ALL ON THE SAME PLANE. As soon as objects start traversing to absolute positions higher than the cell plane, forget about it.

The solution? PROJECTION.

Now when constructing a path, the height of each cell being constructed on is stored in a separate array. This is telling the engine how much the y-component of each path coordinate needs to be reduced to place the object on the base plane.

As an object moves around the path, the height of the object is also being tracked. This is done by computing a ratio of 'distance to travel' / 'distance left', and scaling the current height up/down by that ratio applied to the height left to traverse.

I know that sounds mega complicated, but it's by far the easiest solution. Was going to look at calculating vertical velocity by using trig functions, but what would I use as the base plane to find the theta value? Someone smarter than me could probably figure it out, but screw it - easier to just hammer in some ratio computation.

OH YEAH ALSO ROTATION REQUIRES COORDINATES TO BE RELATIVE TO THE BASE PLANE!!!
To get around this, I've written another rotation function which accounts for height - that is, removes the height component, rotates the coordinates, then re-adds the height component.
Used this to rotate the object paths, object position, and temp path (for in-construction paths).
I'm actually really impressed that I saw this and wrote a solution so quickly. Absolute-height-rotation is a sneaky but ABSOLUTELY VITAL feature for an isometric engine.

Hopefully I never have to write a PR this long ever again...