### PR TITLE
Full z-axis construction now works

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -57,7 +57,6 @@ popup_definition = [
         'right'
       ], [
         'down',
-        'flat',
         'up'
       ]
     ]

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -148,9 +148,9 @@ def render_with_dictionary():
 
           orientation = cell['objectOnCell']['orientation']
 
-          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation % 2) % 4}'], cell[f'v{(orientation % 2) % 4}'])
+          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
           centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
-          end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation % 2) % 4}'], cell[f'v{(2 + orientation % 2) % 4}'])
+          end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation) % 4}'], cell[f'v{(2 + orientation) % 4}'])
 
           # Drawing the line
           glColor(0, 0, 1)
@@ -166,9 +166,9 @@ def render_with_dictionary():
 
           orientation = cell['objectOnCell']['orientation']
 
-          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation % 2) % 4}'], cell[f'v{(orientation % 2) % 4}'])
+          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
           centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
-          end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation % 2) % 4}'], cell[f'v{(2 + orientation % 2) % 4}'])
+          end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation) % 4}'], cell[f'v{(2 + orientation) % 4}'])
 
           
           
@@ -186,9 +186,9 @@ def render_with_dictionary():
 
           orientation = cell['objectOnCell']['orientation']
 
-          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation % 2) % 4}'], cell[f'v{(orientation % 2) % 4}'])
+          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
           centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
-          end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation % 2) % 4}'], cell[f'v{(2 + orientation % 2) % 4}'])
+          end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation) % 4}'], cell[f'v{(2 + orientation) % 4}'])
 
           # Drawing the line
           glColor(0, 0, 1)

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -99,7 +99,7 @@ def render_with_dictionary():
       # For now just going to render straight lines...
       if cell['objectOnCell']:
 
-        if cell['objectOnCell']['type'] == 'line':
+        if cell['objectOnCell']['type'] == 'straight':
 
           # Getting the orientation of the line
           orientation = cell['objectOnCell']['orientation']
@@ -112,8 +112,8 @@ def render_with_dictionary():
           glColor(0, 0, 1)
           glLineWidth(3)
           glBegin(GL_LINE_LOOP)
-          glVertex2f(*add_vectors(start_vertex, [0, cell['height']], [0, cell['objectHeight']], config.camera_offset))
-          glVertex2f(*add_vectors(end_vertex, [0, cell['height']], [0, cell['objectHeight']], config.camera_offset))
+          glVertex2f(*add_vectors(start_vertex, [0, cell['objectHeight']], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell['objectHeight']], config.camera_offset))
           glEnd()
         
         elif cell['objectOnCell']['type'] == 'turn':
@@ -139,9 +139,61 @@ def render_with_dictionary():
           glColor(0, 0, 1)
           glLineWidth(3)
           glBegin(GL_LINE_STRIP)
-          glVertex2f(*add_vectors(start_vertex, [0, cell['height']], [0, cell['objectHeight']], config.camera_offset))
-          glVertex2f(*add_vectors(centre_vertex, [0, cell['height']], [0, cell['objectHeight']], config.camera_offset))
-          glVertex2f(*add_vectors(end_vertex, [0, cell['height']], [0, cell['objectHeight']], config.camera_offset))
+          glVertex2f(*add_vectors(start_vertex, [0, cell['objectHeight']], config.camera_offset))
+          glVertex2f(*add_vectors(centre_vertex, [0, cell['objectHeight']], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell['objectHeight']], config.camera_offset))
+          glEnd()
+
+        elif cell['objectOnCell']['type'] == 'slope':
+
+          orientation = cell['objectOnCell']['orientation']
+
+          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
+          centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
+          end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation % 2) % 4}'], cell[f'v{(2 + orientation % 2) % 4}'])
+
+          # Drawing the line
+          glColor(0, 0, 1)
+          glLineWidth(3)
+          glBegin(GL_LINE_STRIP)
+          glVertex2f(*add_vectors(start_vertex, [0, cell['objectHeight'] - config.unit_height / 2], config.camera_offset))
+          glVertex2f(*add_vectors(centre_vertex, [0, cell['objectHeight']], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell['objectHeight'] + (config.unit_height / 2)], config.camera_offset))
+          glEnd()
+
+        # Now let's try to render slopes, dear god man
+        elif cell['objectOnCell']['type'] == 'straightToSlope':
+
+          orientation = cell['objectOnCell']['orientation']
+
+          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
+          centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
+          end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation % 2) % 4}'], cell[f'v{(2 + orientation % 2) % 4}'])
+
+          # Drawing the line
+          glColor(0, 0, 1)
+          glLineWidth(3)
+          glBegin(GL_LINE_STRIP)
+          glVertex2f(*add_vectors(start_vertex, [0, cell['objectHeight']], config.camera_offset))
+          glVertex2f(*add_vectors(centre_vertex, [0, cell['objectHeight']], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell['objectHeight'] + (config.unit_height / 2)], config.camera_offset))
+          glEnd()
+
+        elif cell['objectOnCell']['type'] == 'slopeToStraight':
+
+          orientation = cell['objectOnCell']['orientation']
+
+          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
+          centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
+          end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation % 2) % 4}'], cell[f'v{(2 + orientation % 2) % 4}'])
+
+          # Drawing the line
+          glColor(0, 0, 1)
+          glLineWidth(3)
+          glBegin(GL_LINE_STRIP)
+          glVertex2f(*add_vectors(start_vertex, [0, cell['objectHeight'] - config.unit_height / 2], config.camera_offset))
+          glVertex2f(*add_vectors(centre_vertex, [0, cell['objectHeight']], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell['objectHeight']], config.camera_offset))
           glEnd()
 
     # Else, if they're an object...

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -148,7 +148,7 @@ def render_with_dictionary():
 
           orientation = cell['objectOnCell']['orientation']
 
-          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
+          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation % 2) % 4}'], cell[f'v{(orientation % 2) % 4}'])
           centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
           end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation % 2) % 4}'], cell[f'v{(2 + orientation % 2) % 4}'])
 
@@ -158,7 +158,7 @@ def render_with_dictionary():
           glBegin(GL_LINE_STRIP)
           glVertex2f(*add_vectors(start_vertex, [0, cell['objectHeight'] - config.unit_height / 2], config.camera_offset))
           glVertex2f(*add_vectors(centre_vertex, [0, cell['objectHeight']], config.camera_offset))
-          glVertex2f(*add_vectors(end_vertex, [0, cell['objectHeight'] + (config.unit_height / 2)], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell['objectHeight'] + config.unit_height / 2], config.camera_offset))
           glEnd()
 
         # Now let's try to render slopes, dear god man
@@ -166,9 +166,12 @@ def render_with_dictionary():
 
           orientation = cell['objectOnCell']['orientation']
 
-          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
+          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation % 2) % 4}'], cell[f'v{(orientation % 2) % 4}'])
           centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
           end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation % 2) % 4}'], cell[f'v{(2 + orientation % 2) % 4}'])
+
+          
+          
 
           # Drawing the line
           glColor(0, 0, 1)
@@ -176,14 +179,14 @@ def render_with_dictionary():
           glBegin(GL_LINE_STRIP)
           glVertex2f(*add_vectors(start_vertex, [0, cell['objectHeight']], config.camera_offset))
           glVertex2f(*add_vectors(centre_vertex, [0, cell['objectHeight']], config.camera_offset))
-          glVertex2f(*add_vectors(end_vertex, [0, cell['objectHeight'] + (config.unit_height / 2)], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell['objectHeight'] + config.unit_height / 2], config.camera_offset))
           glEnd()
 
         elif cell['objectOnCell']['type'] == 'slopeToStraight':
 
           orientation = cell['objectOnCell']['orientation']
 
-          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
+          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation % 2) % 4}'], cell[f'v{(orientation % 2) % 4}'])
           centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
           end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation % 2) % 4}'], cell[f'v{(2 + orientation % 2) % 4}'])
 


### PR DESCRIPTION
OK SO IT LOOKS LIKE THERE ARE A LOT OF CHANGES BUT THERE ARE NOT.

In essence, all I've done here is:
1. Added new global vars to construction.py: 'last_piece_played' and 'current_height'.
2. Changed path-writing to use current_height rather than the height of the cell being built on.
3. Defined three new piece types: 'straightToSlope', 'slopeToStraight', and 'slope'. These are the only three unique pieces - everything else achieved through rotation.
4. Set up the rendering function to accomodate for them.

In rendering phase, the pieces are rendered as such:
a) straightToSlope: -/
b) slopeToStraight: /-
c) slope: /
... which means that the orientation needs to be flipped around based on the cases.

The cases are below:
1. **Up button clicked**: straightToSlope if last_piece_played is straight, slope otherwise. *No rotation*.
2. **Down button clicked**: slopeToStraight if last_piece_played is straight, slope otherwise. *180' rotation*.
3. **Straight button clicked**: slopeToStraight if last_piece_played is up. *No rotation*. straightToSlope if last_piece_played is down. *180' rotation*.

Each time an up or down button are pressed, the current_height variable increases or decreases by a config unit height.

Then in rendering, I've adopted the same vertex cycling pattern from the corners, whereby each vertex is cycled based on what the piece orientation is. start and end vertex are adjusted by half of a unit height - to allow for the lines to line up.

It actually works really well, honestly! The path updates were significantly easier than the rendering, but I think I was just really tired when trying to figure the rendering out last night - got it very quickly today. Also hardly matters - all of that will be replaced by texture rendering once this engine is ready for that.

Very impressed man!!!