### PR TITLE
Delete button added to construction popup

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -58,6 +58,8 @@ popup_definition = [
       ], [
         'down',
         'up'
+      ], [
+        'delete'
       ]
     ]
   }, {

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -11,8 +11,8 @@ direction_mapper = [
 ]
 construction_direction = 0
 
-last_piece_placed = None
 current_height = None
+button_sequence = []
 
 # Use the 'z' key to rotate the orientation of the starting line
 def rotate_starting_piece():
@@ -45,7 +45,7 @@ def collision_detection():
 # Logic for not finishing the path - if the user clicks on one of the other HUD buttons before completion
 def kill_the_path_early():
 
-  global construction_direction
+  global construction_direction, button_sequence
 
   # First - clear all the cells which lines were placed on
   # This pattern was an EXCELLENT idea - good on you for thinking of it early
@@ -60,13 +60,14 @@ def kill_the_path_early():
   config.temp_height = []
   config.construction_cell = None
   construction_direction = 0
+  button_sequence = []
 
   print('PATH HAS BEEN TERMINATED EARLY')
 
 # Logic for completing the path - for when the construction engine meets up with the start of the path!
 def complete_line_construction():
 
-  global construction_direction
+  global construction_direction, button_sequence
 
   # Actions for completion of path:
   # 1. write entry to the 'objects' dictionary
@@ -91,19 +92,20 @@ def complete_line_construction():
   config.construction_cell = None
   config.user_data['mode'] = None
   construction_direction = 0
+  button_sequence = []
 
   print('LINE IS NOW COMPLETE')
 
 
 def place_first_piece_of_line():
 
-  global last_piece_placed, current_height
+  global current_height
 
   # If no current pieces have been placed yet then place the first piece
   if len(config.temp_cells_constructed_on) == 0:
 
     # Setting up the localised construction variables
-    last_piece_placed = 'straight'
+    button_sequence.append('straight')
     current_height = config.gameboard[config.interaction_cells[0]]['height']
 
     # Add a line object to the cell being clicked on
@@ -147,99 +149,128 @@ def z_axis_collision_detection(action):
 # Pretty much the same pattern as above but with the construction_cell being used as reference rather than interaction_cell
 def construct_path_popup(action):
 
-  global construction_direction, last_piece_placed, current_height
+  global construction_direction, current_height, button_sequence
 
   if len(config.temp_cells_constructed_on) != 0:
 
-    if config.can_you_build_here and z_axis_collision_detection(action) == False:
+    # Let's write in the 'delete' button first
+    if action == 'delete':
 
-      # Line orientation == construction direction for left turns
-      # Line orientation == construction direction + 1 for right turns
-      # On the assumption that direction(0) = (1, 0) and rotates counterclockwise per each increment
-      # And orientation of the corner made by direction(0) -> direction(1) is also orientation(0), and also rotates counterclockwise
-      # Worst description of that ever lmao, but draw it out on paper if you ever forget - that's how I just figured it out
+      # 1. Set current height to objectHeight of last constructed piece
+      current_height = config.gameboard[config.temp_cells_constructed_on[-1]]['objectHeight']
       
-      print(f'BUTTON PRESSED: {action}')
+      # 2. Set construction cell to the last cell constructed on
+      #    OR IF DELETING THE FIRST PIECE THEN JUST WIPE IT OUT
+      config.construction_cell = None if len(config.temp_cells_constructed_on) == 1 else config.temp_cells_constructed_on[-1]
 
-      if action == 'left':
-        line_type = 'turn'
-        line_orientation = construction_direction
-        # Update the construction direction to reflect the direction provided in function
-        construction_direction = (construction_direction + 1) % 4
+      # 3. Set construction direction to what it was at prior placement
+      if button_sequence[-1] == 'left': construction_direction = (construction_direction - 1) % 4
+      elif button_sequence[-1] == 'right': construction_direction = (construction_direction + 1) % 4
 
-      elif action == 'right':
-        line_type = 'turn'
-        line_orientation = (1 + construction_direction) % 4
-        # Update the construction direction to reflect the direction provided in function
-        construction_direction = (construction_direction - 1) % 4
+      # 4. Wipe out the object on the cell
+      config.gameboard[config.temp_cells_constructed_on[-1]]['objectOnCell'] = None
+      config.gameboard[config.temp_cells_constructed_on[-1]]['objectHeight'] = None
 
-      # UP BUTTON
-      elif action == 'up':
-        line_type = 'straightToSlope' if last_piece_placed != 'up' else 'slope'
-        line_orientation = construction_direction
+      # 5. Pop the last entries from the Config arrays + button sequence
+      config.temp_cells_constructed_on.pop()
+      config.temp_height.pop()
+      config.temp_path.pop()
+      button_sequence.pop()
 
-      # DOWN BUTTON
-      elif action == 'down':
-        line_type = 'slopeToStraight' if last_piece_placed != 'down' else 'slope'
-        line_orientation = (construction_direction + 2) % 4
-
-      # else - drawing a straight line, which is trivially of orientation == direction
-      elif action == 'straight':
-        if last_piece_placed == 'down':
-          line_type = 'straightToSlope'
-          line_orientation = (construction_direction + 2) % 4
-        elif last_piece_placed == 'up':
-          line_type = 'slopeToStraight'
-          line_orientation = construction_direction
-        else:
-          line_type = 'straight'
-          line_orientation = construction_direction
-
-      # Adding the line object to the cell
-      config.gameboard[config.construction_cell]['objectOnCell'] = {
-        'type': line_type,
-        'orientation': line_orientation
-      }
-      # Specifying the height of the line object - 0 as placeholder
-      config.gameboard[config.construction_cell]['objectHeight'] = current_height
-
-      # Continuing to add to the list of cells constructed on - so we can wipe them out if exit partway through
-      config.temp_cells_constructed_on.append(config.construction_cell)
-
-      # Adding the new point to the temp path
-      config.temp_path.append(
-        find_vector_midpoint(
-          add_vectors(config.gameboard[config.construction_cell]['v2'], [0, current_height]),
-          add_vectors(config.gameboard[config.construction_cell]['v0'], [0, current_height])
-        )
-      )
-
-      # Write current height to temp height array
-      config.temp_height.append(current_height)
-
-      # Increment the working height if up/down arrows have been pressed
-      if action == 'down': current_height -= config.unit_height
-      elif action == 'up': current_height += config.unit_height
-
-      print(f'{action} line placed on cell {config.construction_cell}')
-
-      # increment the construction cell to the next one
-      config.construction_cell = tuple(add_vectors(config.construction_cell, direction_mapper[construction_direction]))
-
-      # Updating the last piece placed variable
-      last_piece_placed = action
-
-      # Is the line complete? If so, let's kill this!
-      if (
-        config.temp_cells_constructed_on[0] == config.construction_cell
-        and construction_direction == config.gameboard[config.construction_cell]['objectOnCell']['orientation']
-      ):
-        complete_line_construction()
-      
-      # If not - then let's see if the next piece is possible to build on 
-      else:
-        collision_detection()
-
-    # What happens if you fail collision tests
+      # 6. Run collision detection on updated construction cell
+      collision_detection()
+    
     else:
-      print('CANT BUILD THAT HERE TRY AGAIN')
+
+      if config.can_you_build_here and z_axis_collision_detection(action) == False:
+
+        # Line orientation == construction direction for left turns
+        # Line orientation == construction direction + 1 for right turns
+        # On the assumption that direction(0) = (1, 0) and rotates counterclockwise per each increment
+        # And orientation of the corner made by direction(0) -> direction(1) is also orientation(0), and also rotates counterclockwise
+        # Worst description of that ever lmao, but draw it out on paper if you ever forget - that's how I just figured it out
+
+        print(f'BUTTON PRESSED: {action}')
+
+        if action == 'left':
+          line_type = 'turn'
+          line_orientation = construction_direction
+          # Update the construction direction to reflect the direction provided in function
+          construction_direction = (construction_direction + 1) % 4
+
+        elif action == 'right':
+          line_type = 'turn'
+          line_orientation = (1 + construction_direction) % 4
+          # Update the construction direction to reflect the direction provided in function
+          construction_direction = (construction_direction - 1) % 4
+
+        # UP BUTTON
+        elif action == 'up':
+          line_type = 'straightToSlope' if button_sequence[-1] != 'up' else 'slope'
+          line_orientation = construction_direction
+
+        # DOWN BUTTON
+        elif action == 'down':
+          line_type = 'slopeToStraight' if button_sequence[-1] != 'down' else 'slope'
+          line_orientation = (construction_direction + 2) % 4
+
+        # else - drawing a straight line, which is trivially of orientation == direction
+        elif action == 'straight':
+          if button_sequence[-1] == 'down':
+            line_type = 'straightToSlope'
+            line_orientation = (construction_direction + 2) % 4
+          elif button_sequence[-1] == 'up':
+            line_type = 'slopeToStraight'
+            line_orientation = construction_direction
+          else:
+            line_type = 'straight'
+            line_orientation = construction_direction
+
+        # Adding the line object to the cell
+        config.gameboard[config.construction_cell]['objectOnCell'] = {
+          'type': line_type,
+          'orientation': line_orientation
+        }
+        # Specifying the height of the line object - 0 as placeholder
+        config.gameboard[config.construction_cell]['objectHeight'] = current_height
+
+        # Continuing to add to the list of cells constructed on - so we can wipe them out if exit partway through
+        config.temp_cells_constructed_on.append(config.construction_cell)
+
+        # Adding the new point to the temp path
+        config.temp_path.append(
+          find_vector_midpoint(
+            add_vectors(config.gameboard[config.construction_cell]['v2'], [0, current_height]),
+            add_vectors(config.gameboard[config.construction_cell]['v0'], [0, current_height])
+          )
+        )
+
+        # Write current height to temp height array
+        config.temp_height.append(current_height)
+
+        # Increment the working height if up/down arrows have been pressed
+        if action == 'down': current_height -= config.unit_height
+        elif action == 'up': current_height += config.unit_height
+
+        print(f'{action} line placed on cell {config.construction_cell}')
+
+        # increment the construction cell to the next one
+        config.construction_cell = tuple(add_vectors(config.construction_cell, direction_mapper[construction_direction]))
+
+        # Log the button pressed - important for deletion of pieces
+        button_sequence.append(action)
+
+        # Is the line complete? If so, let's kill this!
+        if (
+          config.temp_cells_constructed_on[0] == config.construction_cell
+          and construction_direction == config.gameboard[config.construction_cell]['objectOnCell']['orientation']
+        ):
+          complete_line_construction()
+
+        # If not - then let's see if the next piece is possible to build on 
+        else:
+          collision_detection()
+
+      # What happens if you fail collision tests
+      else:
+        print('CANT BUILD THAT HERE TRY AGAIN')

--- a/src/functions/mouse_operations.py
+++ b/src/functions/mouse_operations.py
@@ -86,6 +86,8 @@ def mouse_click_mechanics(button, state, x, y):
           kill_the_path_early()
           config.terraform_scalar = 0
 
+          return
+
       # ---- POPUP BUTTONS ---- #
 
       if config.user_data['mode']:
@@ -97,6 +99,8 @@ def mouse_click_mechanics(button, state, x, y):
 
             # Then perform the function dictated by f'{user mode}_popup', with the button name passed as argument
             globals()[f'{config.user_data['mode']}_popup'](button['name'])
+
+            return
       
       # ---- Bespoke actions ---- #
 


### PR DESCRIPTION
With all this collision detection - you really need a delete button.

1. Button added to popup config file. The way I've written this in made this SO easy - just another row with a single button on it.
2. Added a step in the construct_path_popup() function to do the following on delete button press:
    - reset current height to objectHeight of last cell constructed on
    - set construction cell to last cell constructed on, or None if deleting the only piece in the path
    - backtrace the construction_direction by applying the opposite left/right transformations used in placement
    - delete the object on the last cell
    - pop the last entries on all temp arrays
    - run collision detection

NOTE that in order for this to work properly, I needed to change the last_placed_piece to an array. This is because the decision of what piece to place for z-axis construction depends on the last piece, and with deleting now part of this, I needed to be able to recover the last placed piece at any point along the path.
I'd actually call it an improvement tbh.

Anyways, deletion works great, everything works great, pretty amazing.