### PR TITLE
Multiple line objects on each cell

### DIFF
--- a/src/functions/build_objects.py
+++ b/src/functions/build_objects.py
@@ -49,8 +49,7 @@ def build_iso_gameboard():
         'v3': [v4_x, v4_y],
         'height': config.unit_height,
         'color': gameboard_colors[randint(0, len(gameboard_colors) - 1)],
-        'objectOnCell': None,
-        'objectHeight': None
+        'objectsOnCell': []
       }
 
   # Now return the cells dictionary, as well as the list in which to render the cells

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -234,6 +234,10 @@ def construct_path_popup(action):
           ) else True
         })
 
+        # Removing supports for any pieces which might be above the one just placed
+        for obj in config.gameboard[config.construction_cell]['objectsOnCell']:
+          if obj['height'] > current_height: obj['support'] = False
+
         # Continuing to add to the list of cells constructed on - so we can wipe them out if exit partway through
         config.temp_cells_constructed_on.append(config.construction_cell)
 

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -109,12 +109,11 @@ def place_first_piece_of_line():
     current_height = config.gameboard[config.interaction_cells[0]]['height']
 
     # Add a line object to the cell being clicked on
-    config.gameboard[config.interaction_cells[0]]['objectOnCell'] = {
+    config.gameboard[config.interaction_cells[0]]['objectsOnCell'].append({
       'type': 'straight',
-      'orientation': construction_direction
-    }
-
-    config.gameboard[config.interaction_cells[0]]['objectHeight'] = current_height
+      'orientation': construction_direction,
+      'height': current_height
+    })
 
     # Log the clicked cell as the first cell being constructed on
     config.temp_cells_constructed_on.append(config.interaction_cells[0])
@@ -156,8 +155,8 @@ def construct_path_popup(action):
     # Let's write in the 'delete' button first
     if action == 'delete':
 
-      # 1. Set current height to objectHeight of last constructed piece
-      current_height = config.gameboard[config.temp_cells_constructed_on[-1]]['objectHeight']
+      # 1. Set current height to last recorded temp height
+      current_height = config.temp_height[-1]
       
       # 2. Set construction cell to the last cell constructed on
       #    OR IF DELETING THE FIRST PIECE THEN JUST WIPE IT OUT
@@ -168,8 +167,7 @@ def construct_path_popup(action):
       elif button_sequence[-1] == 'right': construction_direction = (construction_direction + 1) % 4
 
       # 4. Wipe out the object on the cell
-      config.gameboard[config.temp_cells_constructed_on[-1]]['objectOnCell'] = None
-      config.gameboard[config.temp_cells_constructed_on[-1]]['objectHeight'] = None
+      config.gameboard[config.temp_cells_constructed_on[-1]]['objectsOnCell'].pop()
 
       # 5. Pop the last entries from the Config arrays + button sequence
       config.temp_cells_constructed_on.pop()
@@ -227,12 +225,11 @@ def construct_path_popup(action):
             line_orientation = construction_direction
 
         # Adding the line object to the cell
-        config.gameboard[config.construction_cell]['objectOnCell'] = {
+        config.gameboard[config.construction_cell]['objectsOnCell'].append({
           'type': line_type,
-          'orientation': line_orientation
-        }
-        # Specifying the height of the line object - 0 as placeholder
-        config.gameboard[config.construction_cell]['objectHeight'] = current_height
+          'orientation': line_orientation,
+          'height': current_height
+        })
 
         # Continuing to add to the list of cells constructed on - so we can wipe them out if exit partway through
         config.temp_cells_constructed_on.append(config.construction_cell)
@@ -263,7 +260,7 @@ def construct_path_popup(action):
         # Is the line complete? If so, let's kill this!
         if (
           config.temp_cells_constructed_on[0] == config.construction_cell
-          and construction_direction == config.gameboard[config.construction_cell]['objectOnCell']['orientation']
+          and construction_direction == config.gameboard[config.construction_cell]['objectsOnCell'][-1]['orientation']
         ):
           complete_line_construction()
 

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -111,7 +111,8 @@ def place_first_piece_of_line():
     config.gameboard[config.interaction_cells[0]]['objectsOnCell'].append({
       'type': 'straight',
       'orientation': construction_direction,
-      'height': current_height
+      'height': current_height,
+      'support': True
     })
 
     # Log the clicked cell as the first cell being constructed on
@@ -227,7 +228,10 @@ def construct_path_popup(action):
         config.gameboard[config.construction_cell]['objectsOnCell'].append({
           'type': line_type,
           'orientation': line_orientation,
-          'height': current_height
+          'height': current_height,
+          'support': False if any(
+            obj['height'] < current_height for obj in config.gameboard[config.construction_cell]['objectsOnCell']
+          ) else True
         })
 
         # Continuing to add to the list of cells constructed on - so we can wipe them out if exit partway through

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -32,7 +32,7 @@ def collision_detection():
   # Cases we need to account for:
   if (
     # 1: construction cell already has an object on it at the current construction height
-    config.gameboard[config.construction_cell]['objectHeight'] == current_height
+    any(objects['height'] == current_height for objects in config.gameboard[config.construction_cell]['objectsOnCell'])
     # 2: construction cell is higher than current piece attempting to build
     or config.gameboard[config.construction_cell]['height'] > current_height
   ):
@@ -51,8 +51,7 @@ def kill_the_path_early():
   # This pattern was an EXCELLENT idea - good on you for thinking of it early
   for cell_index in config.temp_cells_constructed_on:
 
-    config.gameboard[cell_index]['objectOnCell'] = None
-    config.gameboard[cell_index]['objectHeight'] = None
+    config.gameboard[cell_index]['objectsOnCell'].pop()
   
   # Then just reset all the construction vars back to default
   config.temp_cells_constructed_on = []

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -97,7 +97,7 @@ def render_with_dictionary():
       # ------------------ STATIC OBJECT RENDERING ------------------ #
 
       # For now just going to render straight lines...
-      if cell['objectOnCell']:
+      for cell_object in cell['objectsOnCell']:
 
         # Rendering the support beam underneath the path
         centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
@@ -105,7 +105,7 @@ def render_with_dictionary():
         glLineWidth(3)
         glBegin(GL_LINE_STRIP)
         glVertex2f(*add_vectors(centre_vertex, [0, cell['height']], config.camera_offset))
-        glVertex2f(*add_vectors(centre_vertex, [0, cell['objectHeight']], config.camera_offset))
+        glVertex2f(*add_vectors(centre_vertex, [0, cell_object['height']], config.camera_offset))
         glEnd()
 
         # Rendering the support beam footer
@@ -116,10 +116,10 @@ def render_with_dictionary():
         glVertex2f(*add_vectors(centre_vertex, [0, cell['height'] - 0.007], config.camera_offset))
         glEnd()
 
-        if cell['objectOnCell']['type'] == 'straight':
+        if cell_object['type'] == 'straight':
 
           # Getting the orientation of the line
-          orientation = cell['objectOnCell']['orientation']
+          orientation = cell_object['orientation']
 
           # Dynamically pulling out the required vertices for the line, as per orientation
           start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation % 2) % 4}'], cell[f'v{(orientation % 2) % 4}'])
@@ -129,13 +129,13 @@ def render_with_dictionary():
           glColor(0, 0, 1)
           glLineWidth(4)
           glBegin(GL_LINE_LOOP)
-          glVertex2f(*add_vectors(start_vertex, [0, cell['objectHeight']], config.camera_offset))
-          glVertex2f(*add_vectors(end_vertex, [0, cell['objectHeight']], config.camera_offset))
+          glVertex2f(*add_vectors(start_vertex, [0, cell_object['height']], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell_object['height']], config.camera_offset))
           glEnd()
         
-        elif cell['objectOnCell']['type'] == 'turn':
+        elif cell_object['type'] == 'turn':
 
-          orientation = cell['objectOnCell']['orientation']
+          orientation = cell_object['orientation']
 
           # Doing the same for the turns as the straight lines - though they're about a million times more complex lol
           # So gonna write an index into the comments here to justify the madness inside the find_midpoint function calls
@@ -156,14 +156,14 @@ def render_with_dictionary():
           glColor(0, 0, 1)
           glLineWidth(4)
           glBegin(GL_LINE_STRIP)
-          glVertex2f(*add_vectors(start_vertex, [0, cell['objectHeight']], config.camera_offset))
-          glVertex2f(*add_vectors(centre_vertex, [0, cell['objectHeight']], config.camera_offset))
-          glVertex2f(*add_vectors(end_vertex, [0, cell['objectHeight']], config.camera_offset))
+          glVertex2f(*add_vectors(start_vertex, [0, cell_object['height']], config.camera_offset))
+          glVertex2f(*add_vectors(centre_vertex, [0, cell_object['height']], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell_object['height']], config.camera_offset))
           glEnd()
 
-        elif cell['objectOnCell']['type'] == 'slope':
+        elif cell_object['type'] == 'slope':
 
-          orientation = cell['objectOnCell']['orientation']
+          orientation = cell_object['orientation']
 
           start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
           centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
@@ -173,15 +173,15 @@ def render_with_dictionary():
           glColor(0, 0, 1)
           glLineWidth(4)
           glBegin(GL_LINE_STRIP)
-          glVertex2f(*add_vectors(start_vertex, [0, cell['objectHeight'] - config.unit_height / 2], config.camera_offset))
-          glVertex2f(*add_vectors(centre_vertex, [0, cell['objectHeight']], config.camera_offset))
-          glVertex2f(*add_vectors(end_vertex, [0, cell['objectHeight'] + config.unit_height / 2], config.camera_offset))
+          glVertex2f(*add_vectors(start_vertex, [0, cell_object['height'] - config.unit_height / 2], config.camera_offset))
+          glVertex2f(*add_vectors(centre_vertex, [0, cell_object['height']], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell_object['height'] + config.unit_height / 2], config.camera_offset))
           glEnd()
 
         # Now let's try to render slopes, dear god man
-        elif cell['objectOnCell']['type'] == 'straightToSlope':
+        elif cell_object['type'] == 'straightToSlope':
 
-          orientation = cell['objectOnCell']['orientation']
+          orientation =  cell_object['orientation']
 
           start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
           centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
@@ -194,14 +194,14 @@ def render_with_dictionary():
           glColor(0, 0, 1)
           glLineWidth(4)
           glBegin(GL_LINE_STRIP)
-          glVertex2f(*add_vectors(start_vertex, [0, cell['objectHeight']], config.camera_offset))
-          glVertex2f(*add_vectors(centre_vertex, [0, cell['objectHeight']], config.camera_offset))
-          glVertex2f(*add_vectors(end_vertex, [0, cell['objectHeight'] + config.unit_height / 2], config.camera_offset))
+          glVertex2f(*add_vectors(start_vertex, [0, cell_object['height']], config.camera_offset))
+          glVertex2f(*add_vectors(centre_vertex, [0, cell_object['height']], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell_object['height'] + config.unit_height / 2], config.camera_offset))
           glEnd()
 
-        elif cell['objectOnCell']['type'] == 'slopeToStraight':
+        elif cell_object['type'] == 'slopeToStraight':
 
-          orientation = cell['objectOnCell']['orientation']
+          orientation = cell_object['orientation']
 
           start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
           centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
@@ -211,9 +211,9 @@ def render_with_dictionary():
           glColor(0, 0, 1)
           glLineWidth(4)
           glBegin(GL_LINE_STRIP)
-          glVertex2f(*add_vectors(start_vertex, [0, cell['objectHeight'] - config.unit_height / 2], config.camera_offset))
-          glVertex2f(*add_vectors(centre_vertex, [0, cell['objectHeight']], config.camera_offset))
-          glVertex2f(*add_vectors(end_vertex, [0, cell['objectHeight']], config.camera_offset))
+          glVertex2f(*add_vectors(start_vertex, [0, cell_object['height'] - config.unit_height / 2], config.camera_offset))
+          glVertex2f(*add_vectors(centre_vertex, [0, cell_object['height']], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell_object['height']], config.camera_offset))
           glEnd()
 
     # Else, if they're an object...

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -99,22 +99,23 @@ def render_with_dictionary():
       # For now just going to render straight lines...
       for cell_object in cell['objectsOnCell']:
 
-        # Rendering the support beam underneath the path
-        centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
-        glColor(0.8, 0.8, 0.8)
-        glLineWidth(3)
-        glBegin(GL_LINE_STRIP)
-        glVertex2f(*add_vectors(centre_vertex, [0, cell['height']], config.camera_offset))
-        glVertex2f(*add_vectors(centre_vertex, [0, cell_object['height']], config.camera_offset))
-        glEnd()
+        if cell_object['support']:
+          # Rendering the support beam underneath the path
+          centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
+          glColor(0.8, 0.8, 0.8)
+          glLineWidth(3)
+          glBegin(GL_LINE_STRIP)
+          glVertex2f(*add_vectors(centre_vertex, [0, cell['height']], config.camera_offset))
+          glVertex2f(*add_vectors(centre_vertex, [0, cell_object['height']], config.camera_offset))
+          glEnd()
 
-        # Rendering the support beam footer
-        glLineWidth(5)
-        glColor(0.4, 0.4, 0.4)
-        glBegin(GL_LINE_STRIP)
-        glVertex2f(*add_vectors(centre_vertex, [0, cell['height']], config.camera_offset))
-        glVertex2f(*add_vectors(centre_vertex, [0, cell['height'] - 0.007], config.camera_offset))
-        glEnd()
+          # Rendering the support beam footer
+          glLineWidth(5)
+          glColor(0.4, 0.4, 0.4)
+          glBegin(GL_LINE_STRIP)
+          glVertex2f(*add_vectors(centre_vertex, [0, cell['height']], config.camera_offset))
+          glVertex2f(*add_vectors(centre_vertex, [0, cell['height'] - 0.007], config.camera_offset))
+          glEnd()
 
         if cell_object['type'] == 'straight':
 


### PR DESCRIPTION
Pretty cool one!!

Cells can now have multiple lines at different heights rendered on them.

Achieved this by swapping the 'objectOnCell' and 'objectHeight' attributes for cells into an array of object dictionaries. These have the structure {'type':, 'orientation':, 'height':, 'support':}, with support being a boolean value.

These are then rendered in a loop in the render function.

One little quality-of-life improvement is setting up the support boolean to switch to 'False' if there is a track piece underneath the constructed piece. Stops intersecting supports+track.
This is also set up to delete the supports of anything ABOVE pieces being constructed as lines are being placed - so works both ways. Pretty cool and relatively easy.

DESPERATELY need some condensing of code though - my goodness these functions are getting out of hand...