### PR TITLE
Steep line option

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -56,8 +56,10 @@ popup_definition = [
         'straight',
         'right'
       ], [
+        'downSteep',
         'down',
-        'up'
+        'up',
+        'upSteep'
       ], [
         'delete'
       ]

--- a/src/functions/construction.py
+++ b/src/functions/construction.py
@@ -212,13 +212,29 @@ def construct_path_popup(action):
           line_type = 'slopeToStraight' if button_sequence[-1] != 'down' else 'slope'
           line_orientation = (construction_direction + 2) % 4
 
+        # STEEP UP BUTTON
+        elif action == 'upSteep':
+          line_type = 'straightToSteep' if button_sequence[-1] != 'upSteep' else 'steep'
+          line_orientation = construction_direction
+        
+        # STEEP DOWN BUTTON
+        elif action == 'downSteep':
+          line_type = 'steepToStraight' if button_sequence[-1] != 'downSteep' else 'steep'
+          line_orientation = (construction_direction + 2) % 4
+
         # else - drawing a straight line, which is trivially of orientation == direction
         elif action == 'straight':
-          if button_sequence[-1] == 'down':
+          if button_sequence[-1] == 'downSteep':
+            line_type = 'straightToSteep'
+            line_orientation = (construction_direction + 2) % 4
+          elif button_sequence[-1] == 'down':
             line_type = 'straightToSlope'
             line_orientation = (construction_direction + 2) % 4
           elif button_sequence[-1] == 'up':
             line_type = 'slopeToStraight'
+            line_orientation = construction_direction
+          elif button_sequence[-1] == 'upSteep':
+            line_type = 'steepToStraight'
             line_orientation = construction_direction
           else:
             line_type = 'straight'
@@ -254,7 +270,9 @@ def construct_path_popup(action):
 
         # Increment the working height if up/down arrows have been pressed
         if action == 'down': current_height -= config.unit_height
+        elif action == 'downSteep': current_height -= config.unit_height * 2
         elif action == 'up': current_height += config.unit_height
+        elif action == 'upSteep': current_height += config.unit_height * 2
 
         print(f'{action} line placed on cell {config.construction_cell}')
 

--- a/src/functions/rendering.py
+++ b/src/functions/rendering.py
@@ -179,6 +179,23 @@ def render_with_dictionary():
           glVertex2f(*add_vectors(end_vertex, [0, cell_object['height'] + config.unit_height / 2], config.camera_offset))
           glEnd()
 
+        elif cell_object['type'] == 'steep':
+
+          orientation = cell_object['orientation']
+
+          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
+          centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
+          end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation) % 4}'], cell[f'v{(2 + orientation) % 4}'])
+
+          # Drawing the line
+          glColor(0, 0, 1)
+          glLineWidth(4)
+          glBegin(GL_LINE_STRIP)
+          glVertex2f(*add_vectors(start_vertex, [0, cell_object['height'] - config.unit_height], config.camera_offset))
+          glVertex2f(*add_vectors(centre_vertex, [0, cell_object['height']], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell_object['height'] + config.unit_height], config.camera_offset))
+          glEnd()
+
         # Now let's try to render slopes, dear god man
         elif cell_object['type'] == 'straightToSlope':
 
@@ -187,9 +204,6 @@ def render_with_dictionary():
           start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
           centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
           end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation) % 4}'], cell[f'v{(2 + orientation) % 4}'])
-
-          
-          
 
           # Drawing the line
           glColor(0, 0, 1)
@@ -213,6 +227,40 @@ def render_with_dictionary():
           glLineWidth(4)
           glBegin(GL_LINE_STRIP)
           glVertex2f(*add_vectors(start_vertex, [0, cell_object['height'] - config.unit_height / 2], config.camera_offset))
+          glVertex2f(*add_vectors(centre_vertex, [0, cell_object['height']], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell_object['height']], config.camera_offset))
+          glEnd()
+
+        elif cell_object['type'] == 'straightToSteep':
+
+          orientation =  cell_object['orientation']
+
+          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
+          centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
+          end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation) % 4}'], cell[f'v{(2 + orientation) % 4}'])
+
+          # Drawing the line
+          glColor(0, 0, 1)
+          glLineWidth(4)
+          glBegin(GL_LINE_STRIP)
+          glVertex2f(*add_vectors(start_vertex, [0, cell_object['height']], config.camera_offset))
+          glVertex2f(*add_vectors(centre_vertex, [0, cell_object['height']], config.camera_offset))
+          glVertex2f(*add_vectors(end_vertex, [0, cell_object['height'] + config.unit_height], config.camera_offset))
+          glEnd()
+
+        elif cell_object['type'] == 'steepToStraight':
+
+          orientation = cell_object['orientation']
+
+          start_vertex = find_vector_midpoint(cell[f'v{(3 + orientation) % 4}'], cell[f'v{orientation}'])
+          centre_vertex = find_vector_midpoint(cell['v2'], cell['v0'])
+          end_vertex = find_vector_midpoint(cell[f'v{(1 + orientation) % 4}'], cell[f'v{(2 + orientation) % 4}'])
+
+          # Drawing the line
+          glColor(0, 0, 1)
+          glLineWidth(4)
+          glBegin(GL_LINE_STRIP)
+          glVertex2f(*add_vectors(start_vertex, [0, cell_object['height'] - config.unit_height], config.camera_offset))
           glVertex2f(*add_vectors(centre_vertex, [0, cell_object['height']], config.camera_offset))
           glVertex2f(*add_vectors(end_vertex, [0, cell_object['height']], config.camera_offset))
           glEnd()


### PR DESCRIPTION
Tiny feature addition. Just kinda burned out on this and want to start building a new feature.

Just added a steep line option. Two new buttons, two new line types, both with new render logic. Just adapting the gentle incline logic for everything.

Note that steep lines only work from flats, not from gentles. Not really interested in writing in 5 new line types while the code is completely non-optimised like this. All good - not a big deal!

The real reason I've added these is to truly illustrate why my current 'update position' logic is not optimal. Updates positions based on actual line length, not the theoretical isometric length. Really keen on changing that - and this steep line will allow me to properly see if what I write is working.